### PR TITLE
Ensure _isSpeaking flag is set to false when TTS playback completes. …

### DIFF
--- a/Dissonance/Dissonance/Managers/HotkeyManager .cs
+++ b/Dissonance/Dissonance/Managers/HotkeyManager .cs
@@ -22,6 +22,7 @@ namespace Dissonance.Managers
 			_ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
 			_clipboardManager = clipboardManager ?? throw new ArgumentNullException ( nameof ( clipboardManager ) );
 			_logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
+			_ttsService.SpeechCompleted += OnSpeechCompleted;
 		}
 
 		private void OnHotkeyPressed ( )
@@ -47,6 +48,12 @@ namespace Dissonance.Managers
 			{
 				_logger.LogWarning ( "Clipboard is empty or contains invalid text." );
 			}
+		}
+
+		private void OnSpeechCompleted ( object sender, EventArgs e )
+		{
+			_isSpeaking = false;
+			_logger.LogInformation ( "TTS playback completed." );
 		}
 
 		public void Dispose ( )

--- a/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
@@ -7,5 +7,7 @@
 		void Speak ( string text );
 
 		void Stop ( );
+
+		event EventHandler SpeechCompleted;
 	}
 }

--- a/Dissonance/Dissonance/Services/TTSService/TTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/TTSService.cs
@@ -1,4 +1,5 @@
-﻿using System.Speech.Synthesis;
+﻿using System;
+using System.Speech.Synthesis;
 
 using Dissonance.Infrastructure.Constants;
 
@@ -11,12 +12,14 @@ namespace Dissonance.Services.TTSService
 		private readonly ILogger<TTSService> _logger;
 		private readonly Dissonance.Services.MessageService.IMessageService _messageService;
 		private readonly SpeechSynthesizer _synthesizer;
+		public event EventHandler SpeechCompleted;
 
 		public TTSService ( ILogger<TTSService> logger, Dissonance.Services.MessageService.IMessageService messageService )
 		{
 			_logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
 			_messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
 			_synthesizer = new SpeechSynthesizer ( );
+			_synthesizer.SpeakCompleted += OnSpeakCompleted;
 		}
 
 		public void SetTTSParameters ( string voice, double rate, int volume )
@@ -67,6 +70,11 @@ namespace Dissonance.Services.TTSService
 			{
 				_messageService.DissonanceMessageBoxShowError ( MessageBoxTitles.TTSServiceError, "Failed to stop speaking text due to an unhandled exception.", ex );
 			}
+		}
+
+		private void OnSpeakCompleted ( object sender, SpeakCompletedEventArgs e )
+		{
+			SpeechCompleted?.Invoke ( this, EventArgs.Empty );
 		}
 	}
 }


### PR DESCRIPTION
Ensure _isSpeaking flag is set to false when TTS playback completes

- Subscribed to the SpeechCompleted event in the HotkeyManager constructor.
- Added OnSpeechCompleted method to handle the SpeechCompleted event and set _isSpeaking to false.
- Updated OnHotkeyPressed method to handle stopping and starting TTS playback correctly.