### PR TITLE
Add debug and update steps for Azure DevOps Work Item

### DIFF
--- a/.github/workflows/update-ado-workitem.yml
+++ b/.github/workflows/update-ado-workitem.yml
@@ -14,11 +14,15 @@ jobs:
         id: extract
         run: |
           echo "${{ github.event.pull_request.body }}" | \
-          grep -o 'AB#[0-9]*' | sed 's/AB#//' > workitem.txt
+          grep -o 'AB#[0-9]*' | sed 's/AB#//' > workitem.txt || true
           wid=$(cat workitem.txt)
           echo "workitem_id=$wid" >> $GITHUB_OUTPUT
 
+      - name: Debug Work Item ID
+        run: echo "Extracted Work Item ID: ${{ steps.extract.outputs.workitem_id }}"
+
       - name: Update Azure DevOps Work Item State
+        if: steps.extract.outputs.workitem_id != ''
         env:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           WORK_ITEM_ID: ${{ steps.extract.outputs.workitem_id }}


### PR DESCRIPTION
[AB#38](https://dev.azure.com/DissonanceCo/1a61d05e-eb2b-429b-88c8-aa0097268761/_workitems/edit/38)

Enhance `update-ado-workitem.yml` by adding a debug step to print the extracted Work Item ID. Implement a new step to update the Azure DevOps Work Item state. The extraction process now includes a fallback to prevent failure if no ID is found, improving workflow reliability and visibility.