### PR TITLE
Add jq installation and error handling in workflow

### DIFF
--- a/.github/workflows/update-ado-workitem.yml
+++ b/.github/workflows/update-ado-workitem.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Extract Work Item ID from PR Body
         id: extract
         run: |
@@ -45,7 +48,14 @@ jobs:
           echo "Fetching current work item state..."
           curl -s -H "Content-Type: application/json" -H "$AUTH_HEADER" "$BASE_URL" -o current.json
           cat current.json
+
           CURRENT_STATE=$(jq -r '.fields["System.State"]' current.json)
+
+          if [ -z "$CURRENT_STATE" ] || [ "$CURRENT_STATE" = "null" ]; then
+            echo "ERROR: Could not determine current state from work item data."
+            exit 1
+          fi
+
           echo "Current state: $CURRENT_STATE"
 
           declare -a STATES=("New" "Active" "Resolved" "Closed")


### PR DESCRIPTION
This commit introduces a step to install the `jq` tool for JSON processing in the `update-ado-workitem.yml` file. It also adds error handling to check if the current state of the work item can be determined. If the state is null or not found, an error message is displayed, and the script exits with a non-zero status, improving the workflow's robustness.

[AB#38](https://dev.azure.com/DissonanceCo/1a61d05e-eb2b-429b-88c8-aa0097268761/_workitems/edit/38)