### PR TITLE
Switch app chrome to orange and purple themes

### DIFF
--- a/Dissonance/Dissonance/App.xaml
+++ b/Dissonance/Dissonance/App.xaml
@@ -2,5 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Themes/BaseTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Dissonance/Dissonance/App.xaml.cs
+++ b/Dissonance/Dissonance/App.xaml.cs
@@ -6,6 +6,7 @@ using Dissonance.Services.ClipboardService;
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.MessageService;
 using Dissonance.Services.SettingsService;
+using Dissonance.Services.ThemeService;
 using Dissonance.Services.TTSService;
 using Dissonance.ViewModels;
 
@@ -31,7 +32,8 @@ namespace Dissonance
 		{
 			services.AddSingleton<ISettingsService, SettingsService> ( );
 			services.AddSingleton<IClipboardService, ClipboardService> ( );
-			services.AddSingleton<ITTSService, TTSService> ( );
+                        services.AddSingleton<ITTSService, TTSService> ( );
+                        services.AddSingleton<IThemeService, ThemeService> ( );
 			services.AddSingleton<IHotkeyService, HotkeyService> ( );
 			services.AddSingleton<IMessageService, MessageService> ( );
 			services.AddSingleton<MainWindowViewModel> ( );
@@ -51,7 +53,9 @@ namespace Dissonance
 		{
 			base.OnStartup ( e );
 
-			var logger = _serviceProvider.GetRequiredService<ILogger<App>>();
+                        var logger = _serviceProvider.GetRequiredService<ILogger<App>>();
+                        var themeService = _serviceProvider.GetRequiredService<IThemeService> ( );
+                        themeService.ApplyTheme ( AppTheme.Light );
 			_startupManager = _serviceProvider.GetRequiredService<StartupManager> ( );
 
 			try

--- a/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
@@ -1,0 +1,479 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <FontFamily x:Key="BaseFontFamily">Segoe UI</FontFamily>
+
+    <Thickness x:Key="CardPadding">20</Thickness>
+    <CornerRadius x:Key="CardCornerRadius">18</CornerRadius>
+    <CornerRadius x:Key="InputCornerRadius">10</CornerRadius>
+    <CornerRadius x:Key="ButtonCornerRadius">12</CornerRadius>
+    <CornerRadius x:Key="HeaderCornerRadius">18</CornerRadius>
+    <CornerRadius x:Key="SurfaceCornerRadius">24</CornerRadius>
+
+    <Geometry x:Key="MinimizeIconGeometry">M 3 11 H 13</Geometry>
+    <Geometry x:Key="MaximizeIconGeometry">M 3 3 H 13 V 13 H 3 Z</Geometry>
+    <Geometry x:Key="RestoreIconGeometry">M 5 5 H 13 V 13 H 5 Z M 3 3 H 11 V 11 H 3 Z</Geometry>
+    <Geometry x:Key="CloseIconGeometry">M 4 4 L 12 12 M 12 4 L 4 12</Geometry>
+
+    <Style x:Key="CardContainerStyle" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}"/>
+        <Setter Property="Padding" Value="{StaticResource CardPadding}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CardCornerRadius}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="HeaderTitleTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="30"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="Foreground" Value="{DynamicResource HeaderForegroundBrush}"/>
+    </Style>
+
+    <Style x:Key="HeaderSubtitleTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="Opacity" Value="0.85"/>
+        <Setter Property="Foreground" Value="{DynamicResource HeaderForegroundBrush}"/>
+    </Style>
+
+    <Style x:Key="WindowTitleTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{DynamicResource TitleBarForegroundBrush}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Opacity" Value="0.9"/>
+    </Style>
+
+    <Style x:Key="CardTitleTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="18"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}"/>
+    </Style>
+
+    <Style x:Key="CardDescriptionTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}"/>
+        <Setter Property="Margin" Value="0,4,0,12"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <Style x:Key="ValueBadgeTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+    </Style>
+
+    <Style x:Key="WindowControlButtonStyle" TargetType="Button">
+        <Setter Property="Width" Value="36"/>
+        <Setter Property="Height" Value="32"/>
+        <Setter Property="Margin" Value="6,0,0,0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource TitleBarForegroundBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="8"
+                            SnapsToDevicePixels="True">
+                        <Viewbox Width="14"
+                                 Height="14"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center">
+                            <Path Data="{TemplateBinding Content}"
+                                  Stroke="{TemplateBinding Foreground}"
+                                  StrokeThickness="1.6"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"/>
+                        </Viewbox>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowControlHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowControlPressedBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MaximizeWindowControlButtonStyle" TargetType="Button" BasedOn="{StaticResource WindowControlButtonStyle}">
+        <Setter Property="Content" Value="{StaticResource MaximizeIconGeometry}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=WindowState}" Value="Maximized">
+                <Setter Property="Content" Value="{StaticResource RestoreIconGeometry}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="CloseWindowControlButtonStyle" TargetType="Button" BasedOn="{StaticResource WindowControlButtonStyle}">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource CloseControlHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource CloseControlPressedBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}"/>
+        <Setter Property="Padding" Value="16,8"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="{StaticResource ButtonCornerRadius}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ControlHoverBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ControlPressedBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Border" Property="Opacity" Value="0.6"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ThemeToggleButtonStyle" TargetType="ToggleButton">
+        <Setter Property="Width" Value="82"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="SwitchBackground"
+                            Background="{DynamicResource ToggleBackgroundBrush}"
+                            CornerRadius="18"
+                            Padding="6"
+                            SnapsToDevicePixels="True">
+                        <Grid>
+                            <TextBlock Text="☀"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Center"
+                                       Margin="4,0,0,0"/>
+                            <TextBlock Text="🌙"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,4,0"/>
+                            <Border x:Name="Thumb"
+                                    Width="28"
+                                    Height="28"
+                                    Background="{DynamicResource ThemeToggleThumbBrush}"
+                                    CornerRadius="14"
+                                    HorizontalAlignment="Left"
+                                    SnapsToDevicePixels="True"/>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="SwitchBackground" Property="Background" Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="Thumb" Property="HorizontalAlignment" Value="Right"/>
+                            <Setter TargetName="Thumb" Property="Background" Value="{DynamicResource ButtonForegroundBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Thumb" Property="Background" Value="{DynamicResource ControlHoverBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ModernTextBoxStyle" TargetType="TextBox">
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource InputForegroundBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="MinHeight" Value="34"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource InputCornerRadius}">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="0"
+                                      Focusable="False"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Border" Property="Opacity" Value="0.6"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="Border" Property="BorderThickness" Value="2"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ModernComboBoxItemStyle" TargetType="ComboBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="Border"
+                            Background="Transparent"
+                            CornerRadius="8"
+                            Padding="12,6"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource SubtleBackgroundBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ModernComboBoxStyle" TargetType="ComboBox">
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource InputForegroundBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ModernComboBoxItemStyle}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <Border x:Name="BackgroundBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{StaticResource InputCornerRadius}"
+                                SnapsToDevicePixels="True"/>
+                        <ToggleButton x:Name="DropDownToggle"
+                                      Focusable="False"
+                                      Background="Transparent"
+                                      BorderBrush="{x:Null}"
+                                      BorderThickness="0"
+                                      Margin="0"
+                                      Padding="0"
+                                      ClickMode="Press"
+                                      HorizontalContentAlignment="Stretch"
+                                      VerticalContentAlignment="Stretch"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  Margin="12,0,16,0"
+                                                  HorizontalAlignment="Left"
+                                                  VerticalAlignment="Center"
+                                                  RecognizesAccessKey="True"
+                                                  TextElement.Foreground="{TemplateBinding Foreground}"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                  ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"/>
+                                <Path x:Name="DropDownGlyph"
+                                      Grid.Column="1"
+                                      Data="M 0 0 L 6 6 L 12 0"
+                                      StrokeThickness="2"
+                                      StrokeEndLineCap="Round"
+                                      Stroke="{DynamicResource SecondaryForegroundBrush}"
+                                      Stretch="Uniform"
+                                      Width="12"
+                                      Height="6"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,12,0"/>
+                            </Grid>
+                        </ToggleButton>
+                        <TextBox x:Name="PART_EditableTextBox"
+                                 Margin="12,0,36,0"
+                                 Style="{x:Null}"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 HorizontalAlignment="Stretch"
+                                 VerticalContentAlignment="Center"
+                                 Foreground="{TemplateBinding Foreground}"
+                                 Visibility="Hidden"
+                                 Focusable="True"
+                                 Padding="0"
+                                 Text="{TemplateBinding Text}"
+                                 IsReadOnly="False"
+                                 CaretBrush="{DynamicResource AccentBrush}"/>
+                        <Popup x:Name="PART_Popup"
+                               AllowsTransparency="True"
+                               Placement="Bottom"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               PlacementTarget="{Binding ElementName=DropDownToggle}"
+                               Focusable="False"
+                               PopupAnimation="Fade"
+                               StaysOpen="False">
+                            <Border x:Name="PopupBorder"
+                                    Background="{DynamicResource CardBackgroundBrush}"
+                                    BorderBrush="{DynamicResource CardBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="4"
+                                    SnapsToDevicePixels="True">
+                                <ScrollViewer Margin="0"
+                                              CanContentScroll="True"
+                                              Focusable="False">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="BackgroundBorder" Property="BorderBrush" Value="{DynamicResource ControlHoverBrush}"/>
+                            <Setter TargetName="DropDownGlyph" Property="Stroke" Value="{DynamicResource ControlHoverBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="BackgroundBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="BackgroundBorder" Property="BorderThickness" Value="2"/>
+                            <Setter TargetName="DropDownGlyph" Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsDropDownOpen" Value="True">
+                            <Setter TargetName="BackgroundBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="DropDownGlyph" Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="HasItems" Value="False">
+                            <Setter TargetName="PopupBorder" Property="MinHeight" Value="0"/>
+                        </Trigger>
+                        <Trigger Property="IsEditable" Value="True">
+                            <Setter TargetName="ContentPresenter" Property="Visibility" Value="Hidden"/>
+                            <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="PART_EditableTextBox" Property="IsHitTestVisible" Value="True"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.6"/>
+                            <Setter TargetName="DropDownGlyph" Property="Stroke" Value="{DynamicResource MutedForegroundBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SliderRepeatButtonStyle" TargetType="RepeatButton">
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="2"
+                            Height="4"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ModernSliderStyle" TargetType="Slider">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid Margin="0,12,0,8">
+                        <Border Background="{DynamicResource SliderTrackBackgroundBrush}"
+                                Height="4"
+                                CornerRadius="2"
+                                VerticalAlignment="Center"/>
+                        <Track x:Name="PART_Track"
+                               Maximum="{TemplateBinding Maximum}"
+                               Minimum="{TemplateBinding Minimum}"
+                               Value="{TemplateBinding Value}"
+                               Margin="0"
+                               IsDirectionReversed="{TemplateBinding IsDirectionReversed}">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SliderRepeatButtonStyle}"
+                                              Background="{DynamicResource AccentBrush}"/>
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SliderRepeatButtonStyle}"
+                                              Background="Transparent"/>
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb x:Name="Thumb"
+                                       Width="18"
+                                       Height="18"
+                                       Background="{DynamicResource AccentBrush}"
+                                       BorderBrush="{DynamicResource SliderThumbBorderBrush}"
+                                       BorderThickness="2"/>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.6"/>
+                        </Trigger>
+                        <Trigger SourceName="Thumb" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Thumb" Property="Background" Value="{DynamicResource ControlHoverBrush}"/>
+                        </Trigger>
+                        <Trigger SourceName="Thumb" Property="IsDragging" Value="True">
+                            <Setter TargetName="Thumb" Property="Background" Value="{DynamicResource ControlPressedBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/Dissonance/Dissonance/Resources/Themes/DarkTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/DarkTheme.xaml
@@ -1,0 +1,64 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="WindowBackgroundColor">#FF160B24</Color>
+    <Color x:Key="SurfaceBackgroundColor">#FF1D132C</Color>
+    <Color x:Key="CardBackgroundColor">#FF241336</Color>
+    <Color x:Key="CardBorderColor">#FF3A2350</Color>
+    <Color x:Key="PrimaryForegroundColor">#FFF7EEFF</Color>
+    <Color x:Key="SecondaryForegroundColor">#FFC7B6E1</Color>
+    <Color x:Key="HeaderForegroundColor">#FFFDF8FF</Color>
+    <Color x:Key="MutedForegroundColor">#FFA893D1</Color>
+    <Color x:Key="AccentColor">#FFFF914D</Color>
+    <Color x:Key="ControlHoverColor">#FFFFA767</Color>
+    <Color x:Key="ControlPressedColor">#FFD87830</Color>
+    <Color x:Key="ButtonForegroundColor">#FF1C0E1C</Color>
+    <Color x:Key="ToggleBackgroundColor">#FF2E1C44</Color>
+    <Color x:Key="ToggleThumbColor">#FFF7EEFF</Color>
+    <Color x:Key="InputBackgroundColor">#FF2E1B43</Color>
+    <Color x:Key="InputBorderColor">#FF4A2A60</Color>
+    <Color x:Key="InputForegroundColor">#FFF7EEFF</Color>
+    <Color x:Key="SubtleBackgroundColor">#FF372051</Color>
+    <Color x:Key="SliderTrackBackgroundColor">#FF2F1E48</Color>
+    <Color x:Key="SliderThumbBorderColor">#FF140A21</Color>
+    <Color x:Key="HeaderGradientStartColor">#FF52279E</Color>
+    <Color x:Key="HeaderGradientEndColor">#FFFF7D42</Color>
+    <Color x:Key="TitleBarBackgroundColor">#FF27143F</Color>
+    <Color x:Key="TitleBarForegroundColor">#FFF4ECFF</Color>
+    <Color x:Key="WindowControlHoverColor">#FF3C2756</Color>
+    <Color x:Key="WindowControlPressedColor">#FF51306F</Color>
+    <Color x:Key="CloseControlHoverColor">#FF5A2C3C</Color>
+    <Color x:Key="CloseControlPressedColor">#FF7E3448</Color>
+
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="SurfaceBackgroundBrush" Color="{StaticResource SurfaceBackgroundColor}"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}"/>
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="{StaticResource PrimaryForegroundColor}"/>
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="{StaticResource SecondaryForegroundColor}"/>
+    <SolidColorBrush x:Key="HeaderForegroundBrush" Color="{StaticResource HeaderForegroundColor}"/>
+    <SolidColorBrush x:Key="MutedForegroundBrush" Color="{StaticResource MutedForegroundColor}"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
+    <SolidColorBrush x:Key="ControlHoverBrush" Color="{StaticResource ControlHoverColor}"/>
+    <SolidColorBrush x:Key="ControlPressedBrush" Color="{StaticResource ControlPressedColor}"/>
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="{StaticResource ButtonForegroundColor}"/>
+    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="{StaticResource ToggleBackgroundColor}"/>
+    <SolidColorBrush x:Key="ThemeToggleThumbBrush" Color="{StaticResource ToggleThumbColor}"/>
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}"/>
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}"/>
+    <SolidColorBrush x:Key="InputForegroundBrush" Color="{StaticResource InputForegroundColor}"/>
+    <SolidColorBrush x:Key="SubtleBackgroundBrush" Color="{StaticResource SubtleBackgroundColor}"/>
+    <SolidColorBrush x:Key="SliderTrackBackgroundBrush" Color="{StaticResource SliderTrackBackgroundColor}"/>
+    <SolidColorBrush x:Key="SliderThumbBorderBrush" Color="{StaticResource SliderThumbBorderColor}"/>
+    <SolidColorBrush x:Key="TitleBarBackgroundBrush" Color="{StaticResource TitleBarBackgroundColor}"/>
+    <SolidColorBrush x:Key="TitleBarForegroundBrush" Color="{StaticResource TitleBarForegroundColor}"/>
+    <SolidColorBrush x:Key="WindowControlHoverBrush" Color="{StaticResource WindowControlHoverColor}"/>
+    <SolidColorBrush x:Key="WindowControlPressedBrush" Color="{StaticResource WindowControlPressedColor}"/>
+    <SolidColorBrush x:Key="CloseControlHoverBrush" Color="{StaticResource CloseControlHoverColor}"/>
+    <SolidColorBrush x:Key="CloseControlPressedBrush" Color="{StaticResource CloseControlPressedColor}"/>
+
+    <LinearGradientBrush x:Key="HeaderBackgroundBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="{StaticResource HeaderGradientStartColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource HeaderGradientEndColor}" Offset="1"/>
+    </LinearGradientBrush>
+</ResourceDictionary>

--- a/Dissonance/Dissonance/Resources/Themes/LightTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/LightTheme.xaml
@@ -1,0 +1,64 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="WindowBackgroundColor">#FFFCF8FF</Color>
+    <Color x:Key="SurfaceBackgroundColor">#FFFEFDFF</Color>
+    <Color x:Key="CardBackgroundColor">#FFFFFFFF</Color>
+    <Color x:Key="CardBorderColor">#FFE9DEF7</Color>
+    <Color x:Key="PrimaryForegroundColor">#FF2B143A</Color>
+    <Color x:Key="SecondaryForegroundColor">#FF6D587F</Color>
+    <Color x:Key="HeaderForegroundColor">#FFFFFFFF</Color>
+    <Color x:Key="MutedForegroundColor">#FFA489C5</Color>
+    <Color x:Key="AccentColor">#FFFF7A45</Color>
+    <Color x:Key="ControlHoverColor">#FFFF955D</Color>
+    <Color x:Key="ControlPressedColor">#FFE36B2A</Color>
+    <Color x:Key="ButtonForegroundColor">#FFFFFFFF</Color>
+    <Color x:Key="ToggleBackgroundColor">#FFF3E8FF</Color>
+    <Color x:Key="ToggleThumbColor">#FFFFFFFF</Color>
+    <Color x:Key="InputBackgroundColor">#FFFBF8FF</Color>
+    <Color x:Key="InputBorderColor">#FFE5D9F8</Color>
+    <Color x:Key="InputForegroundColor">#FF2B143A</Color>
+    <Color x:Key="SubtleBackgroundColor">#FFF4E8FF</Color>
+    <Color x:Key="SliderTrackBackgroundColor">#FFEADCF9</Color>
+    <Color x:Key="SliderThumbBorderColor">#FFFFFFFF</Color>
+    <Color x:Key="HeaderGradientStartColor">#FF7F3BFF</Color>
+    <Color x:Key="HeaderGradientEndColor">#FFFF8A4C</Color>
+    <Color x:Key="TitleBarBackgroundColor">#FFF1E5FF</Color>
+    <Color x:Key="TitleBarForegroundColor">#FF301740</Color>
+    <Color x:Key="WindowControlHoverColor">#FFFFE0D0</Color>
+    <Color x:Key="WindowControlPressedColor">#FFFFC4A3</Color>
+    <Color x:Key="CloseControlHoverColor">#FFFFD8D6</Color>
+    <Color x:Key="CloseControlPressedColor">#FFFFBAB7</Color>
+
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="SurfaceBackgroundBrush" Color="{StaticResource SurfaceBackgroundColor}"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}"/>
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="{StaticResource PrimaryForegroundColor}"/>
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="{StaticResource SecondaryForegroundColor}"/>
+    <SolidColorBrush x:Key="HeaderForegroundBrush" Color="{StaticResource HeaderForegroundColor}"/>
+    <SolidColorBrush x:Key="MutedForegroundBrush" Color="{StaticResource MutedForegroundColor}"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
+    <SolidColorBrush x:Key="ControlHoverBrush" Color="{StaticResource ControlHoverColor}"/>
+    <SolidColorBrush x:Key="ControlPressedBrush" Color="{StaticResource ControlPressedColor}"/>
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="{StaticResource ButtonForegroundColor}"/>
+    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="{StaticResource ToggleBackgroundColor}"/>
+    <SolidColorBrush x:Key="ThemeToggleThumbBrush" Color="{StaticResource ToggleThumbColor}"/>
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}"/>
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}"/>
+    <SolidColorBrush x:Key="InputForegroundBrush" Color="{StaticResource InputForegroundColor}"/>
+    <SolidColorBrush x:Key="SubtleBackgroundBrush" Color="{StaticResource SubtleBackgroundColor}"/>
+    <SolidColorBrush x:Key="SliderTrackBackgroundBrush" Color="{StaticResource SliderTrackBackgroundColor}"/>
+    <SolidColorBrush x:Key="SliderThumbBorderBrush" Color="{StaticResource SliderThumbBorderColor}"/>
+    <SolidColorBrush x:Key="TitleBarBackgroundBrush" Color="{StaticResource TitleBarBackgroundColor}"/>
+    <SolidColorBrush x:Key="TitleBarForegroundBrush" Color="{StaticResource TitleBarForegroundColor}"/>
+    <SolidColorBrush x:Key="WindowControlHoverBrush" Color="{StaticResource WindowControlHoverColor}"/>
+    <SolidColorBrush x:Key="WindowControlPressedBrush" Color="{StaticResource WindowControlPressedColor}"/>
+    <SolidColorBrush x:Key="CloseControlHoverBrush" Color="{StaticResource CloseControlHoverColor}"/>
+    <SolidColorBrush x:Key="CloseControlPressedBrush" Color="{StaticResource CloseControlPressedColor}"/>
+
+    <LinearGradientBrush x:Key="HeaderBackgroundBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="{StaticResource HeaderGradientStartColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource HeaderGradientEndColor}" Offset="1"/>
+    </LinearGradientBrush>
+</ResourceDictionary>

--- a/Dissonance/Dissonance/Services/ThemeService/AppTheme.cs
+++ b/Dissonance/Dissonance/Services/ThemeService/AppTheme.cs
@@ -1,0 +1,8 @@
+namespace Dissonance.Services.ThemeService
+{
+        public enum AppTheme
+        {
+                Light,
+                Dark
+        }
+}

--- a/Dissonance/Dissonance/Services/ThemeService/IThemeService.cs
+++ b/Dissonance/Dissonance/Services/ThemeService/IThemeService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Dissonance.Services.ThemeService
+{
+        public interface IThemeService
+        {
+                IReadOnlyCollection<AppTheme> AvailableThemes { get; }
+
+                AppTheme CurrentTheme { get; }
+
+                void ApplyTheme ( AppTheme theme );
+        }
+}

--- a/Dissonance/Dissonance/Services/ThemeService/ThemeService.cs
+++ b/Dissonance/Dissonance/Services/ThemeService/ThemeService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace Dissonance.Services.ThemeService
+{
+        internal class ThemeService : IThemeService
+        {
+                private static readonly IReadOnlyCollection<AppTheme> ThemeValues = Array.AsReadOnly(new[]
+                {
+                        AppTheme.Light,
+                        AppTheme.Dark
+                });
+
+                private readonly object _syncLock = new object ( );
+                private readonly Uri _baseThemeUri = new Uri ( "Resources/Themes/BaseTheme.xaml", UriKind.Relative );
+                private readonly Uri _darkThemeUri = new Uri ( "Resources/Themes/DarkTheme.xaml", UriKind.Relative );
+                private readonly Uri _lightThemeUri = new Uri ( "Resources/Themes/LightTheme.xaml", UriKind.Relative );
+
+                public IReadOnlyCollection<AppTheme> AvailableThemes => ThemeValues;
+
+                public AppTheme CurrentTheme { get; private set; } = AppTheme.Light;
+
+                public void ApplyTheme ( AppTheme theme )
+                {
+                        var application = Application.Current ?? throw new InvalidOperationException ( "Application resources are unavailable." );
+
+                        if ( application.Dispatcher.CheckAccess ( ) )
+                        {
+                                ApplyThemeInternal ( application.Resources, theme );
+                        }
+                        else
+                        {
+                                application.Dispatcher.Invoke ( ( ) => ApplyThemeInternal ( application.Resources, theme ) );
+                        }
+                }
+
+                private void ApplyThemeInternal ( ResourceDictionary resources, AppTheme theme )
+                {
+                        lock ( _syncLock )
+                        {
+                                EnsureDictionary ( resources, _baseThemeUri );
+
+                                var themeUri = theme == AppTheme.Dark ? _darkThemeUri : _lightThemeUri;
+
+                                RemoveDictionary ( resources, _lightThemeUri );
+                                RemoveDictionary ( resources, _darkThemeUri );
+
+                                resources.MergedDictionaries.Add ( new ResourceDictionary { Source = themeUri } );
+
+                                CurrentTheme = theme;
+                        }
+                }
+
+                private static void EnsureDictionary ( ResourceDictionary resources, Uri source )
+                {
+                        if ( resources.MergedDictionaries.Any ( dictionary => dictionary.Source == source ) )
+                                return;
+
+                        resources.MergedDictionaries.Add ( new ResourceDictionary { Source = source } );
+                }
+
+                private static void RemoveDictionary ( ResourceDictionary resources, Uri source )
+                {
+                        var dictionary = resources.MergedDictionaries.FirstOrDefault ( rd => rd.Source == source );
+                        if ( dictionary != null )
+                        {
+                                resources.MergedDictionaries.Remove ( dictionary );
+                        }
+                }
+        }
+}

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -1,115 +1,239 @@
-﻿<Window x:Name="Dissonance" x:Class="Dissonance.MainWindow"
+<Window x:Name="Dissonance"
+        x:Class="Dissonance.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:Dissonance.ViewModels"
+        xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
         mc:Ignorable="d"
-        Title="Dissonance" Height="409" Width="800" WindowStartupLocation="CenterScreen" BorderBrush="White" Background="White">
-    <Grid x:Name="DissonanceGrid" ScrollViewer.VerticalScrollBarVisibility="Disabled" Grid.IsSharedSizeScope="True">
+        Title="Dissonance"
+        MinHeight="520"
+        MinWidth="880"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        ResizeMode="CanResize"
+        AllowsTransparency="False"
+        Background="{DynamicResource WindowBackgroundBrush}"
+        Foreground="{DynamicResource PrimaryForegroundBrush}"
+        FontFamily="{DynamicResource BaseFontFamily}"
+        d:DataContext="{d:DesignInstance Type=local:MainWindowViewModel}">
+    <shell:WindowChrome.WindowChrome>
+        <shell:WindowChrome CaptionHeight="0"
+                             CornerRadius="0"
+                             GlassFrameThickness="0"
+                             ResizeBorderThickness="6"/>
+    </shell:WindowChrome.WindowChrome>
+    <Grid Background="{DynamicResource PrimaryBackgroundBrush}">
         <Grid.RowDefinitions>
-            <RowDefinition Height="1.5*"/>
-            <RowDefinition Height="2*"/>
-            <RowDefinition Height="2*"/>
-            <RowDefinition Height="3*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="0.75*"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
 
-        <Label x:Name="DissonanceTitleLable" Content="Dissonance" VerticalAlignment="Center" FontSize="28"
-               HorizontalAlignment="Center" Grid.Column="1" Height="48" Width="150"
-               HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
+        <Border Grid.Row="0"
+                Margin="24,24,24,12"
+                Padding="16,0"
+                CornerRadius="{StaticResource HeaderCornerRadius}"
+                Background="{DynamicResource TitleBarBackgroundBrush}"
+                SnapsToDevicePixels="True"
+                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Horizontal"
+                            VerticalAlignment="Center"
+                            Margin="0,0,16,0">
+                    <Border Width="8"
+                            Height="8"
+                            CornerRadius="4"
+                            Background="{DynamicResource AccentBrush}"
+                            VerticalAlignment="Center"
+                            Margin="0,0,8,0"/>
+                    <TextBlock Text="Dissonance"
+                               Style="{StaticResource WindowTitleTextStyle}"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center">
+                    <Button Style="{StaticResource WindowControlButtonStyle}"
+                            Margin="0"
+                            Content="{StaticResource MinimizeIconGeometry}"
+                            ToolTip="Minimize"
+                            Click="MinimizeButton_Click"/>
+                    <Button Style="{StaticResource MaximizeWindowControlButtonStyle}"
+                            ToolTip="Maximize or restore"
+                            Click="MaximizeButton_Click"/>
+                    <Button Style="{StaticResource CloseWindowControlButtonStyle}"
+                            Content="{StaticResource CloseIconGeometry}"
+                            ToolTip="Close"
+                            Click="CloseButton_Click"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
-        <Grid x:Name="VoiceRateGrid" ScrollViewer.VerticalScrollBarVisibility="Disabled" Grid.Row="1"
-              HorizontalAlignment="Center" MinHeight="92.48" MaxHeight="92.48">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <Label x:Name="VoiceRateHeadingLable" Content="Voice Rate" FontSize="18"
-                   VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
-                   HorizontalAlignment="Center" Width="115" Height="32" VerticalAlignment="Center" MaxHeight="85"/>
-            <TextBox x:Name="VoiceRateTextBox"
-                     TextWrapping="Wrap"
-                     Text="{Binding VoiceRate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                     AutomationProperties.LabeledBy="{Binding ElementName=VoiceRateHeadingLable}"
-                     TabIndex="1" AllowDrop="False" HorizontalAlignment="Center" VerticalAlignment="Center"
-                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Width="96"
-                     Grid.Row="1" Height="27" ToolTip="Set the speaking rate of the text-to-speech voice" MinHeight="27"/>
-        </Grid>
+        <Border Grid.Row="1"
+                Margin="24,12,24,0"
+                Padding="24"
+                CornerRadius="{StaticResource HeaderCornerRadius}"
+                Background="{DynamicResource HeaderBackgroundBrush}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Dissonance"
+                               Style="{StaticResource HeaderTitleTextStyle}"/>
+                    <TextBlock Text="Accessibility-first speech control center"
+                               Style="{StaticResource HeaderSubtitleTextStyle}"
+                               Margin="0,10,0,0"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{Binding CurrentThemeName}"
+                               Foreground="{DynamicResource HeaderForegroundBrush}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,12,0"/>
+                    <ToggleButton Style="{StaticResource ThemeToggleButtonStyle}"
+                                  IsChecked="{Binding IsDarkTheme, Mode=TwoWay}"
+                                  ToolTip="Toggle between light and dark themes"
+                                  AutomationProperties.Name="Toggle between light and dark theme"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
-        <Grid x:Name="VolumeGrid" MinHeight="92.48" MaxHeight="92.48" Grid.Column="1" Grid.Row="2"
-              HorizontalAlignment="Center" Height="92.48" Width="172">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <Label x:Name="VolumeHeadingLable" Content="Volume" FontSize="18"
-                   VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
-                   VerticalAlignment="Center" HorizontalAlignment="Center" Margin="22,0,0,0"/>
-            <Slider x:Name="VoiceVolumeSlider"
-                    Minimum="0" Maximum="100"
-                    Value="{Binding Volume, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    Grid.Row="1" TabIndex="4" Interval="10" IsMoveToPointEnabled="True"
-                    HorizontalAlignment="Center" VerticalAlignment="Center" Width="134"/>
-        </Grid>
+        <Border Grid.Row="2"
+                Margin="24,12,24,24"
+                Padding="24"
+                CornerRadius="{StaticResource SurfaceCornerRadius}"
+                Background="{DynamicResource SurfaceBackgroundBrush}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
 
-        <Grid x:Name="VoiceSelectionGrid" Grid.Column="1" HorizontalAlignment="Center" Width="220"
-              MinWidth="220" Height="92.48" MinHeight="92.48" MaxHeight="92.48" Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <Label x:Name="VoiceSelectionHeadingLable" Content="TTS Voice" FontSize="18"
-                   VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
-                   VerticalAlignment="Center" HorizontalAlignment="Center" Height="34" Width="86"/>
-            <ComboBox x:Name="VoiceSelectionComboBox"
-                      ItemsSource="{Binding AvailableVoices}"
-                      SelectedItem="{Binding Voice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                      AutomationProperties.LabeledBy="{Binding ElementName=VoiceSelectionHeadingLable}"
-                      Grid.Row="1" TabIndex="2" BorderThickness="1,1,1,1"
-                      VerticalContentAlignment="Center" Padding="5,5,5,5" VerticalAlignment="Center"
-                      HorizontalAlignment="Center" Width="170" ToolTip="Select the text-to-speech voice you would like to use"
-                      Text="{Binding Voice, Mode=TwoWay}" MinHeight="27" Height="27">
-                <ComboBox.Background>
-                    <LinearGradientBrush EndPoint="0,1">
-                        <GradientStop Color="#FFF0F0F0"/>
-                        <GradientStop Color="White" Offset="1"/>
-                    </LinearGradientBrush>
-                </ComboBox.Background>
-            </ComboBox>
-        </Grid>
+                <Border Style="{StaticResource CardContainerStyle}"
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="0,0,12,12">
+                    <StackPanel>
+                        <TextBlock x:Name="VoiceSelectionHeading"
+                                   Text="Text-to-Speech Voice"
+                                   Style="{StaticResource CardTitleTextStyle}"/>
+                        <TextBlock Text="Choose which installed voice is used for speech."
+                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                        <ComboBox x:Name="VoiceSelectionComboBox"
+                                  Style="{StaticResource ModernComboBoxStyle}"
+                                  ItemsSource="{Binding AvailableVoices}"
+                                  SelectedItem="{Binding Voice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  AutomationProperties.LabeledBy="{Binding ElementName=VoiceSelectionHeading}"
+                                  ToolTip="Select the voice used by the text-to-speech engine"
+                                  TabIndex="2"
+                                  MinWidth="220"
+                                  MinHeight="34"/>
+                    </StackPanel>
+                </Border>
 
-        <Grid x:Name="ReadClipboardHotkeySelectionGrid" Grid.Column="2" HorizontalAlignment="Center"
-              Width="220" MinWidth="220" Height="92.48" MinHeight="92.48" MaxHeight="92.48" Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <Label x:Name="ReadClipboardHotkeySelectionHeadingLabel" Content="Speak Clipboard Hotkey" FontSize="18"
-                   VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
-                   VerticalAlignment="Center" HorizontalAlignment="Center" Height="34" Width="200"/>
-            <StackPanel Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBox x:Name="ReadClipboardHotkeyTextBox"
-                         TextWrapping="Wrap"
-                         Text="{Binding HotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         AutomationProperties.LabeledBy="{Binding ElementName=ReadClipboardHotkeySelectionHeadingLabel}"
-                         HorizontalAlignment="Center" VerticalAlignment="Center" Width="140"
-                         Height="28" TabIndex="3" MinHeight="27"
-                         ToolTip="Set the hotkey used to trigger speaking the clipboard's text"/>
-                <Button Content="Apply"
-                        Command="{Binding ApplyHotkeyCommand}"
-                        Margin="8,0,0,0"
-                        Padding="10,0"
-                        Height="28"
-                        MinWidth="48"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Left"
-                        ToolTip="Apply the new hotkey"/>
-            </StackPanel>
-        </Grid>
+                <Border Style="{StaticResource CardContainerStyle}"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Margin="12,0,0,12">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="VoiceRateHeading"
+                                       Text="Voice Rate"
+                                       Style="{StaticResource CardTitleTextStyle}"/>
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding VoiceRate, StringFormat={}{0:F0}×}"
+                                       VerticalAlignment="Center"
+                                       Style="{StaticResource ValueBadgeTextStyle}"/>
+                        </Grid>
+                        <TextBlock Text="Fine tune how quickly the narration plays back."
+                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                        <TextBox x:Name="VoiceRateTextBox"
+                                 Style="{StaticResource ModernTextBoxStyle}"
+                                 Text="{Binding VoiceRate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=VoiceRateHeading}"
+                                 ToolTip="Set the speaking rate of the text-to-speech voice"
+                                 HorizontalAlignment="Left"
+                                 HorizontalContentAlignment="Center"
+                                 Width="140"
+                                 TabIndex="1"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource CardContainerStyle}"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="0,12,12,0">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="VolumeHeading"
+                                       Text="Volume"
+                                       Style="{StaticResource CardTitleTextStyle}"/>
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding Volume, StringFormat={}{0}%}"
+                                       VerticalAlignment="Center"
+                                       Style="{StaticResource ValueBadgeTextStyle}"/>
+                        </Grid>
+                        <TextBlock Text="Adjust how loud the speech output should be."
+                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                        <Slider x:Name="VoiceVolumeSlider"
+                                Style="{StaticResource ModernSliderStyle}"
+                                Minimum="0"
+                                Maximum="100"
+                                Value="{Binding Volume, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                ToolTip="Set the output volume for text-to-speech"
+                                AutomationProperties.Name="Voice volume"
+                                TabIndex="4"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource CardContainerStyle}"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Margin="12,12,0,0">
+                    <StackPanel>
+                        <TextBlock x:Name="HotkeyHeading"
+                                   Text="Speak Clipboard Hotkey"
+                                   Style="{StaticResource CardTitleTextStyle}"/>
+                        <TextBlock Text="Define the shortcut that instantly voices your clipboard."
+                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBox x:Name="ReadClipboardHotkeyTextBox"
+                                     Style="{StaticResource ModernTextBoxStyle}"
+                                     Text="{Binding HotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     AutomationProperties.LabeledBy="{Binding ElementName=HotkeyHeading}"
+                                     ToolTip="Set the hotkey used to trigger speaking the clipboard's text"
+                                     Width="170"
+                                     TabIndex="3"/>
+                            <Button Content="Apply"
+                                    Style="{StaticResource PrimaryButtonStyle}"
+                                    Command="{Binding ApplyHotkeyCommand}"
+                                    Margin="12,0,0,0"
+                                    MinWidth="72"
+                                    ToolTip="Apply the new hotkey immediately"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
     </Grid>
 </Window>

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -1,18 +1,75 @@
-﻿using System.Windows;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 
 using Dissonance.ViewModels;
 
 namespace Dissonance
 {
-	public partial class MainWindow : Window
-	{
-		private readonly MainWindowViewModel _viewModel;
+        public partial class MainWindow : Window
+        {
+                private readonly MainWindowViewModel _viewModel;
 
-		public MainWindow ( MainWindowViewModel viewModel )
-		{
-			_viewModel = viewModel ?? throw new ArgumentNullException ( nameof ( viewModel ) );
-			InitializeComponent ( );
-			DataContext = _viewModel;
-		}
-	}
+                public MainWindow ( MainWindowViewModel viewModel )
+                {
+                        _viewModel = viewModel ?? throw new ArgumentNullException ( nameof ( viewModel ) );
+                        InitializeComponent ( );
+                        DataContext = _viewModel;
+                }
+
+                private void MinimizeButton_Click ( object sender, RoutedEventArgs e )
+                {
+                        WindowState = WindowState.Minimized;
+                }
+
+                private void MaximizeButton_Click ( object sender, RoutedEventArgs e )
+                {
+                        ToggleWindowState ( );
+                }
+
+                private void CloseButton_Click ( object sender, RoutedEventArgs e )
+                {
+                        Close ( );
+                }
+
+                private void TitleBar_MouseLeftButtonDown ( object sender, MouseButtonEventArgs e )
+                {
+                        if ( e.OriginalSource is DependencyObject originalSource && IsWithinWindowControl ( originalSource ) )
+                        {
+                                return;
+                        }
+
+                        if ( e.ClickCount == 2 && ResizeMode != ResizeMode.NoResize )
+                        {
+                                ToggleWindowState ( );
+                                return;
+                        }
+
+                        DragMove ( );
+                }
+
+                private void ToggleWindowState ( )
+                {
+                        WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+                }
+
+                private static bool IsWithinWindowControl ( DependencyObject source )
+                {
+                        DependencyObject? current = source;
+
+                        while ( current != null )
+                        {
+                                if ( current is Button )
+                                {
+                                        return true;
+                                }
+
+                                current = VisualTreeHelper.GetParent ( current );
+                        }
+
+                        return false;
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- retune the light and dark palettes to a rich orange and purple scheme, adding title bar and window-control brushes
- extend the base theme with reusable window chrome resources and button templates for minimize, maximize, and close actions
- rebuild MainWindow with a custom draggable title bar that uses the new styles and exposes themed window control buttons

## Testing
- `dotnet build Dissonance.sln` *(fails: `dotnet` is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d296ce617c832db0eccb2a5844e04e