### PR TITLE
Tighten intro banner and theme toggle spacing

### DIFF
--- a/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
@@ -207,7 +207,7 @@
     </Style>
 
     <Style x:Key="ThemeToggleButtonStyle" TargetType="ToggleButton">
-        <Setter Property="Width" Value="82"/>
+        <Setter Property="Width" Value="90"/>
         <Setter Property="Height" Value="36"/>
         <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="BorderThickness" Value="0"/>
@@ -238,6 +238,7 @@
                                     Background="{DynamicResource ThemeToggleThumbBrush}"
                                     CornerRadius="14"
                                     HorizontalAlignment="Left"
+                                    Margin="2,0"
                                     SnapsToDevicePixels="True"/>
                         </Grid>
                     </Border>

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -75,8 +75,8 @@
         </Border>
 
         <Border Grid.Row="1"
-                Margin="24,12,24,0"
-                Padding="24"
+                Margin="24,6,24,0"
+                Padding="20,10"
                 CornerRadius="{StaticResource HeaderCornerRadius}"
                 Background="{DynamicResource HeaderBackgroundBrush}">
             <Grid>
@@ -150,7 +150,8 @@
                     <TextBlock Text="{Binding CurrentThemeName}"
                                Foreground="{DynamicResource HeaderForegroundBrush}"
                                FontWeight="SemiBold"
-                               Margin="0,0,12,0"/>
+                               Margin="0,0,12,0"
+                               VerticalAlignment="Center"/>
                     <ToggleButton Style="{StaticResource ThemeToggleButtonStyle}"
                                   IsChecked="{Binding IsDarkTheme, Mode=TwoWay}"
                                   ToolTip="Toggle between light and dark themes"


### PR DESCRIPTION
## Summary
- reduce the intro banner's padding and margin to make the header section thinner
- center the current theme label alongside the toggle control
- widen the theme toggle thumb spacing so the control no longer clips itself

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2b2acdf18832dbe5f86b675f9e28c