### PR TITLE
Remove redundant save settings option

### DIFF
--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -41,7 +41,6 @@ namespace Dissonance.ViewModels
                         _themeService = themeService ?? throw new ArgumentNullException ( nameof ( themeService ) );
                         _messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
 
-                        SaveSettingsCommand = new RelayCommandNoParam ( SaveCurrentConfiguration );
                         SaveDefaultSettingsCommand = new RelayCommandNoParam ( SaveCurrentConfigurationAsDefault );
                         ExportSettingsCommand = new RelayCommandNoParam ( ExportConfiguration );
                         ImportSettingsCommand = new RelayCommandNoParam ( ImportConfiguration );
@@ -78,8 +77,6 @@ namespace Dissonance.ViewModels
                 public ICommand ImportSettingsCommand { get; }
 
                 public ICommand SaveDefaultSettingsCommand { get; }
-
-                public ICommand SaveSettingsCommand { get; }
 
                 public bool IsDarkTheme
                 {
@@ -295,15 +292,6 @@ namespace Dissonance.ViewModels
                         if ( ApplyHotkeyCommand is RelayCommandNoParam relay )
                         {
                                 relay.RaiseCanExecuteChanged ( );
-                        }
-                }
-
-                private void SaveCurrentConfiguration ( )
-                {
-                        if ( _settingsService.SaveCurrentSettings ( ) )
-                        {
-                                ReloadSettingsFromService ( false );
-                                _messageService.DissonanceMessageBoxShowInfo ( MessageBoxTitles.SettingsServiceInfo, "Configuration saved.", TimeSpan.FromSeconds ( 20 ) );
                         }
                 }
 

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -127,26 +127,17 @@
                                                   Color="#99000000"/>
                             </Border.Effect>
                             <StackPanel FocusManager.IsFocusScope="True"
-                                        FocusManager.FocusedElement="{Binding ElementName=SaveSettingsMenuButton}"
+                                        FocusManager.FocusedElement="{Binding ElementName=SaveSettingsAsDefaultMenuButton}"
                                         KeyboardNavigation.TabNavigation="Cycle"
                                         KeyboardNavigation.ControlTabNavigation="Cycle"
                                         KeyboardNavigation.DirectionalNavigation="Cycle">
-                                <Button x:Name="SaveSettingsMenuButton"
-                                        Style="{StaticResource DropdownMenuButtonStyle}"
-                                        Content="Save current settings"
-                                        Command="{Binding SaveSettingsCommand}"
-                                        Click="SettingsMenuItem_Click"
-                                        Margin="0,0,0,6"
-                                        TabIndex="0"
-                                        AutomationProperties.Name="Save current settings"
-                                        AutomationProperties.HelpText="Saves the current configuration to the active profile"/>
                                 <Button x:Name="SaveSettingsAsDefaultMenuButton"
                                         Style="{StaticResource DropdownMenuButtonStyle}"
                                         Content="Save current settings as default"
                                         Command="{Binding SaveDefaultSettingsCommand}"
                                         Click="SettingsMenuItem_Click"
                                         Margin="0,0,0,6"
-                                        TabIndex="1"
+                                        TabIndex="0"
                                         AutomationProperties.Name="Save current settings as default"
                                         AutomationProperties.HelpText="Saves the configuration so it loads automatically next time"/>
                                 <Border Height="1"
@@ -157,7 +148,7 @@
                                          IsChecked="{Binding SaveConfigAsDefaultOnClose, Mode=TwoWay}"
                                          Click="SettingsMenuAutoSave_Click"
                                          Margin="0,0,0,6"
-                                         TabIndex="2"
+                                         TabIndex="1"
                                          AutomationProperties.Name="Auto-save default on close"
                                          AutomationProperties.HelpText="Automatically write the current configuration as the default when the app is closed"/>
                                 <Border Height="1"
@@ -168,14 +159,14 @@
                                         Command="{Binding ExportSettingsCommand}"
                                         Click="SettingsMenuItem_Click"
                                         Margin="0,0,0,6"
-                                        TabIndex="3"
+                                        TabIndex="2"
                                         AutomationProperties.Name="Export settings"
                                         AutomationProperties.HelpText="Exports the current configuration to a file"/>
                                 <Button Style="{StaticResource DropdownMenuButtonStyle}"
                                         Content="Import settings..."
                                         Command="{Binding ImportSettingsCommand}"
                                         Click="SettingsMenuItem_Click"
-                                        TabIndex="4"
+                                        TabIndex="3"
                                         AutomationProperties.Name="Import settings"
                                         AutomationProperties.HelpText="Imports a configuration from a saved file"/>
                             </StackPanel>

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -189,7 +189,7 @@ namespace Dissonance
 
                 private void SettingsMenuPopup_Opened ( object? sender, EventArgs e )
                 {
-                        Dispatcher.BeginInvoke ( new Action ( ( ) => SaveSettingsMenuButton.Focus ( ) ), DispatcherPriority.Input );
+                        Dispatcher.BeginInvoke ( new Action ( ( ) => SaveSettingsAsDefaultMenuButton.Focus ( ) ), DispatcherPriority.Input );
                 }
 
                 private void SettingsMenuPopup_Closed ( object? sender, EventArgs e )


### PR DESCRIPTION
## Summary
- remove the redundant "Save current settings" option from the settings menu
- drop the unused save command from the main window view model
- retarget the popup focus logic to the remaining default-save action

## Testing
- dotnet build *(fails: `dotnet` command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bcb81b78832daf71e73b7d0b130c