### PR TITLE
Improve accessibility metadata and keyboard navigation

### DIFF
--- a/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
@@ -292,6 +292,9 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="ToolTipService.ToolTip" Value="{Binding Description, FallbackValue=Open this section}"/>
+        <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+        <Setter Property="AutomationProperties.HelpText" Value="{Binding Description, FallbackValue=Open this section}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">

--- a/Dissonance/Dissonance/Windows/Controls/DissonanceMessageBox.xaml
+++ b/Dissonance/Dissonance/Windows/Controls/DissonanceMessageBox.xaml
@@ -17,13 +17,19 @@
         Background="{DynamicResource WindowBackgroundBrush}"
         Foreground="{DynamicResource PrimaryForegroundBrush}"
         FontFamily="{DynamicResource BaseFontFamily}"
-        SnapsToDevicePixels="True">
+        SnapsToDevicePixels="True"
+        AutomationProperties.Name="{Binding Title}"
+        AutomationProperties.HelpText="Dissonance alert dialog">
     <Window.Resources>
         <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Window.Resources>
 
     <Border Margin="24"
-            Style="{StaticResource CardContainerStyle}">
+            Style="{StaticResource CardContainerStyle}"
+            FocusManager.IsFocusScope="True"
+            FocusManager.FocusedElement="{Binding ElementName=OkButton}"
+            KeyboardNavigation.TabNavigation="Cycle"
+            KeyboardNavigation.ControlTabNavigation="Cycle">
         <Border.Effect>
             <DropShadowEffect BlurRadius="18"
                               ShadowDepth="0"
@@ -57,20 +63,32 @@
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="0,20,0,0">
-                <Button Content="OK"
+                <Button x:Name="OkButton"
+                        Content="OK"
                         MinWidth="120"
                         Height="36"
                         Margin="0,0,8,0"
                         Style="{StaticResource PrimaryButtonStyle}"
-                        Command="{Binding OkCommand}" />
-                <Button Content="Cancel"
+                        Command="{Binding OkCommand}"
+                        ToolTip="Confirm and close this alert"
+                        TabIndex="0"
+                        IsDefault="True"
+                        AutomationProperties.Name="Confirm alert"
+                        AutomationProperties.HelpText="Confirms the alert and closes the dialog" />
+                <Button x:Name="CancelButton"
+                        Content="Cancel"
                         MinWidth="120"
                         Height="36"
                         Style="{StaticResource PrimaryButtonStyle}"
                         Command="{Binding CancelCommand}"
                         Visibility="{Binding ShowCancelButton, Converter={StaticResource BoolToVisibilityConverter}}"
                         Background="{DynamicResource CardBorderBrush}"
-                        Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                        Foreground="{DynamicResource PrimaryForegroundBrush}"
+                        ToolTip="Cancel and close this alert"
+                        TabIndex="1"
+                        IsCancel="True"
+                        AutomationProperties.Name="Cancel alert"
+                        AutomationProperties.HelpText="Cancels the action and closes the dialog" />
             </StackPanel>
         </Grid>
     </Border>

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -214,11 +214,15 @@
                             AutomationProperties.HelpText="Minimizes the application window"
                             Click="MinimizeButton_Click"/>
                     <Button Style="{StaticResource MaximizeWindowControlButtonStyle}"
-                            ToolTip="Maximize or restore"
+                            ToolTip="Maximize or restore window"
+                            AutomationProperties.Name="Maximize or restore window"
+                            AutomationProperties.HelpText="Toggles between maximized and windowed layouts"
                             Click="MaximizeButton_Click"/>
                     <Button Style="{StaticResource CloseWindowControlButtonStyle}"
                             Content="{StaticResource CloseIconGeometry}"
-                            ToolTip="Close"
+                            ToolTip="Close window"
+                            AutomationProperties.Name="Close window"
+                            AutomationProperties.HelpText="Closes the Dissonance application"
                             Click="CloseButton_Click"/>
                 </StackPanel>
             </Grid>
@@ -239,6 +243,7 @@
                               Style="{StaticResource NavigationToggleButtonStyle}"
                               IsChecked="{Binding IsNavigationMenuOpen, Mode=TwoWay}"
                               ToolTip="Toggle navigation menu"
+                              TabIndex="0"
                               AutomationProperties.Name="Toggle navigation menu"
                               AutomationProperties.HelpText="Shows the available Dissonance tools"/>
                 <Popup x:Name="NavigationMenuPopup"
@@ -272,6 +277,8 @@
                                     Command="{Binding NavigateToSectionCommand}"
                                     CommandParameter="{x:Null}"
                                     Margin="0,0,0,8"
+                                    ToolTip="Return to the Dissonance home dashboard"
+                                    TabIndex="0"
                                     AutomationProperties.Name="Home"
                                     AutomationProperties.HelpText="Return to the main Dissonance dashboard">
                                 <TextBlock Text="Home"
@@ -288,6 +295,11 @@
                                      Background="Transparent"
                                      Foreground="{DynamicResource PrimaryForegroundBrush}"
                                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                     ToolTip="Select a section to open"
+                                     TabIndex="1"
+                                     PreviewKeyDown="NavigationListBox_PreviewKeyDown"
+                                     AutomationProperties.Name="Available sections"
+                                     AutomationProperties.HelpText="Use the arrow keys to choose a section and press Enter to open it"
                                      SelectionMode="Single"
                                      HorizontalContentAlignment="Stretch"
                                      ItemContainerStyle="{StaticResource NavigationMenuListBoxItemStyle}">
@@ -387,6 +399,7 @@
                                 Height="36"
                                 MinWidth="110"
                                 Margin="0,0,12,0"
+                                ToolTip="Open settings menu"
                                 TabIndex="0"
                                 AutomationProperties.Name="Open settings menu"
                                 AutomationProperties.HelpText="Opens a list of configuration options"
@@ -423,6 +436,7 @@
                                             Click="SettingsMenuItem_Click"
                                             Margin="0,0,0,6"
                                             TabIndex="0"
+                                            ToolTip="Save the current configuration as the default"
                                             AutomationProperties.Name="Save current settings as default"
                                             AutomationProperties.HelpText="Saves the configuration so it loads automatically next time"/>
                                     <Border Height="1"
@@ -434,6 +448,7 @@
                                              Click="SettingsMenuAutoSave_Click"
                                              Margin="0,0,0,6"
                                              TabIndex="1"
+                                             ToolTip="Automatically save the configuration when closing the app"
                                              AutomationProperties.Name="Auto-save default on close"
                                              AutomationProperties.HelpText="Automatically write the current configuration as the default when the app is closed"/>
                                     <Border Height="1"
@@ -445,6 +460,7 @@
                                             Click="SettingsMenuItem_Click"
                                             Margin="0,0,0,6"
                                             TabIndex="2"
+                                            ToolTip="Export the current configuration to a file"
                                             AutomationProperties.Name="Export settings"
                                             AutomationProperties.HelpText="Exports the current configuration to a file"/>
                                     <Button Style="{StaticResource DropdownMenuButtonStyle}"
@@ -452,6 +468,7 @@
                                             Command="{Binding ImportSettingsCommand}"
                                             Click="SettingsMenuItem_Click"
                                             TabIndex="3"
+                                            ToolTip="Import a configuration from a saved file"
                                             AutomationProperties.Name="Import settings"
                                             AutomationProperties.HelpText="Imports a configuration from a saved file"/>
                                 </StackPanel>
@@ -466,7 +483,8 @@
                                       IsChecked="{Binding IsDarkTheme, Mode=TwoWay}"
                                       ToolTip="Toggle between light and dark themes"
                                       TabIndex="1"
-                                      AutomationProperties.Name="Toggle between light and dark theme"/>
+                                      AutomationProperties.Name="Toggle between light and dark theme"
+                                      AutomationProperties.HelpText="Switches between the light and dark themes"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -527,8 +545,9 @@
                                         Margin="0,0,24,24"
                                         Command="{Binding DataContext.NavigateToSectionCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                         CommandParameter="{Binding}"
+                                        ToolTip="{Binding Description, FallbackValue=Open this section}"
                                         AutomationProperties.Name="{Binding Title}"
-                                        AutomationProperties.HelpText="Open this section">
+                                        AutomationProperties.HelpText="{Binding Description, FallbackValue=Open this section}">
                                     <StackPanel>
                                         <TextBlock Text="{Binding Title}"
                                                    FontSize="18"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -227,6 +227,29 @@ namespace Dissonance
                         NavigationToggleButton.Focus ( );
                 }
 
+                private void NavigationListBox_PreviewKeyDown ( object sender, KeyEventArgs e )
+                {
+                        if ( ( e.Key == Key.Enter || e.Key == Key.Space ) && Keyboard.Modifiers == ModifierKeys.None )
+                        {
+                                if ( NavigationListBox.SelectedItem is NavigationSectionViewModel section )
+                                {
+                                        if ( _viewModel.NavigateToSectionCommand?.CanExecute ( section ) == true )
+                                        {
+                                                _viewModel.NavigateToSectionCommand.Execute ( section );
+                                                e.Handled = true;
+                                        }
+                                }
+                        }
+                        else if ( e.Key == Key.Escape )
+                        {
+                                if ( NavigationMenuPopup.IsOpen )
+                                {
+                                        NavigationMenuPopup.IsOpen = false;
+                                        e.Handled = true;
+                                }
+                        }
+                }
+
                 private void ReadClipboardHotkeyTextBox_PreviewKeyDown ( object sender, KeyEventArgs e )
                 {
                         var key = e.Key == Key.System ? e.SystemKey : e.Key;


### PR DESCRIPTION
## Summary
- extend tooltips and automation metadata across window controls, navigation, and settings actions
- handle Enter/Space/Escape in the navigation list to ensure full keyboard control of menu actions
- update the alert dialog to manage focus, default buttons, and automation properties for assistive tech

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d40b5cf5b0832d8c3b82e2efe0e2ea