### PR TITLE
Adjust theme toggle padding to prevent clipping

### DIFF
--- a/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
+++ b/Dissonance/Dissonance/Resources/Themes/BaseTheme.xaml
@@ -428,7 +428,7 @@
                     <Border x:Name="SwitchBackground"
                             Background="{DynamicResource ToggleBackgroundBrush}"
                             CornerRadius="18"
-                            Padding="6"
+                            Padding="6,4"
                             SnapsToDevicePixels="True">
                         <Grid>
                             <TextBlock Text="☀"


### PR DESCRIPTION
## Summary
- reduce the vertical padding around the theme toggle thumb so it has enough room to render cleanly

## Testing
- dotnet test *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d421270748832da0b60e86116cf3d0