### PR TITLE
Place settings controls in shared header

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -355,7 +355,7 @@
                                    Style="{StaticResource HeaderSubtitleTextStyle}"
                                    Margin="0,10,0,0"/>
                     </StackPanel>
-                    <StackPanel DataContext="{Binding SelectedSection}">
+                    <StackPanel>
                         <StackPanel.Style>
                             <Style TargetType="StackPanel">
                                 <Setter Property="Visibility" Value="Visible"/>
@@ -366,11 +366,11 @@
                                 </Style.Triggers>
                             </Style>
                         </StackPanel.Style>
-                        <TextBlock Text="{Binding BannerTitle}"
+                        <TextBlock Text="{Binding SelectedSection.BannerTitle}"
                                    FontSize="24"
                                    FontWeight="Bold"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                        <TextBlock Text="{Binding Description}"
+                        <TextBlock Text="{Binding SelectedSection.Description}"
                                    FontSize="14"
                                    Margin="0,6,0,0"
                                    Foreground="{DynamicResource SecondaryForegroundBrush}"
@@ -389,7 +389,7 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
-                        <TextBlock Text="{Binding BannerSubtitle}"
+                        <TextBlock Text="{Binding SelectedSection.BannerSubtitle}"
                                    FontSize="14"
                                    Margin="0,6,0,0"
                                    Foreground="{DynamicResource SecondaryForegroundBrush}">
@@ -398,6 +398,9 @@
                                     <Setter Property="Visibility" Value="Visible"/>
                                     <Style.Triggers>
                                         <Trigger Property="Text" Value="">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </Trigger>
+                                        <Trigger Property="Text" Value="{x:Null}">
                                             <Setter Property="Visibility" Value="Collapsed"/>
                                         </Trigger>
                                     </Style.Triggers>


### PR DESCRIPTION
## Summary
- show the settings and theme controls for both the home dashboard and tool sections
- consolidate the header layout so the banner styling adjusts based on which view is active

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d421452f40832d952b8e74ee319099