### PR TITLE
Add auto-read clipboard support

### DIFF
--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -29,6 +29,8 @@ namespace Dissonance
                         public string Key { get; set; }
 
                         public string Modifiers { get; set; }
+
+                        public bool AutoReadClipboard { get; set; }
                 }
         }
 }

--- a/Dissonance/Dissonance/Infrastructure/Constants/WindowsMessages.cs
+++ b/Dissonance/Dissonance/Infrastructure/Constants/WindowsMessages.cs
@@ -6,8 +6,9 @@ using System.Threading.Tasks;
 
 namespace Dissonance.Infrastructure.Constants
 {
-	internal static class WindowsMessages
-	{
-		public const int Hotkey = 0x0312;
-	}
+        internal static class WindowsMessages
+        {
+                public const int Hotkey = 0x0312;
+                public const int ClipboardUpdate = 0x031D;
+        }
 }

--- a/Dissonance/Dissonance/Managers/ClipboardManager .cs
+++ b/Dissonance/Dissonance/Managers/ClipboardManager .cs
@@ -1,35 +1,218 @@
-﻿using Dissonance.Services.ClipboardService;
+using System;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Interop;
+
+using Dissonance.Infrastructure.Constants;
+using Dissonance.Services.ClipboardService;
 
 using Microsoft.Extensions.Logging;
 
 namespace Dissonance.Managers
 {
-	public class ClipboardManager
-	{
-		private readonly IClipboardService _clipboardService;
-		private readonly ILogger<ClipboardManager> _logger;
+        public class ClipboardManager : IDisposable
+        {
+                private readonly IClipboardService _clipboardService;
+                private readonly ILogger<ClipboardManager> _logger;
+                private HwndSource? _hwndSource;
+                private bool _autoReadEnabled;
+                private bool _isListenerRegistered;
+                private bool _disposed;
 
-		public ClipboardManager ( IClipboardService clipboardService, ILogger<ClipboardManager> logger )
-		{
-			_clipboardService = clipboardService ?? throw new ArgumentNullException ( nameof ( clipboardService ) );
-			_logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
-		}
+                public ClipboardManager ( IClipboardService clipboardService, ILogger<ClipboardManager> logger )
+                {
+                        _clipboardService = clipboardService ?? throw new ArgumentNullException ( nameof ( clipboardService ) );
+                        _logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
+                }
 
-		public string GetValidatedClipboardText ( )
-		{
-			var text = _clipboardService.GetClipboardText();
-			if ( string.IsNullOrWhiteSpace ( text ) )
-			{
-				_logger.LogWarning ( "Clipboard is empty or contains invalid text." );
-				return null;
-			}
+                public event EventHandler<string>? ClipboardTextReady;
 
-			return text;
-		}
+                public string? GetValidatedClipboardText ( )
+                {
+                        var text = _clipboardService.GetClipboardText();
+                        var sanitized = SanitizeClipboardText ( text );
+                        if ( string.IsNullOrEmpty ( sanitized ) )
+                        {
+                                _logger.LogWarning ( "Clipboard is empty or contains invalid text." );
+                                return null;
+                        }
 
-		public void Initialize ( )
-		{
-			_logger.LogInformation ( "ClipboardManager initialized." );
-		}
-	}
+                        return sanitized;
+                }
+
+                public void Initialize ( MainWindow mainWindow )
+                {
+                        if ( mainWindow == null )
+                                throw new ArgumentNullException ( nameof ( mainWindow ) );
+
+                        mainWindow.SourceInitialized += OnMainWindowSourceInitialized;
+                        mainWindow.Closed += OnMainWindowClosed;
+
+                        if ( mainWindow.IsLoaded )
+                        {
+                                AttachToWindow ( mainWindow );
+                        }
+
+                        _logger.LogInformation ( "ClipboardManager initialized." );
+                }
+
+                public void SetAutoReadClipboard ( bool enabled )
+                {
+                        if ( _autoReadEnabled == enabled )
+                                return;
+
+                        _autoReadEnabled = enabled;
+                        UpdateClipboardListener ( );
+                }
+
+                public void Dispose ( )
+                {
+                        if ( _disposed )
+                                return;
+
+                        _disposed = true;
+
+                        if ( _hwndSource != null )
+                        {
+                                if ( _isListenerRegistered )
+                                {
+                                        RemoveClipboardListener ( );
+                                }
+
+                                _hwndSource.RemoveHook ( WndProc );
+                                _hwndSource = null;
+                        }
+                }
+
+                private void OnMainWindowSourceInitialized ( object? sender, EventArgs e )
+                {
+                        if ( sender is not Window window )
+                                return;
+
+                        AttachToWindow ( window );
+                }
+
+                private void OnMainWindowClosed ( object? sender, EventArgs e )
+                {
+                        if ( _hwndSource != null )
+                        {
+                                if ( _isListenerRegistered )
+                                        RemoveClipboardListener ( );
+
+                                _hwndSource.RemoveHook ( WndProc );
+                                _hwndSource = null;
+                        }
+                }
+
+                private void AttachToWindow ( Window window )
+                {
+                        var source = PresentationSource.FromVisual ( window ) as HwndSource;
+                        if ( source == null )
+                        {
+                                _logger.LogWarning ( "Unable to attach clipboard listener. Window handle not available." );
+                                return;
+                        }
+
+                        if ( _hwndSource != null && _hwndSource.Handle == source.Handle )
+                        {
+                                UpdateClipboardListener ( );
+                                return;
+                        }
+
+                        if ( _hwndSource != null )
+                        {
+                                _hwndSource.RemoveHook ( WndProc );
+                                if ( _isListenerRegistered )
+                                {
+                                        RemoveClipboardListener ( );
+                                }
+                        }
+
+                        _hwndSource = source;
+                        _hwndSource.AddHook ( WndProc );
+                        UpdateClipboardListener ( );
+                }
+
+                private void UpdateClipboardListener ( )
+                {
+                        if ( _hwndSource == null )
+                        {
+                                _logger.LogDebug ( "Clipboard listener update deferred until window handle is available." );
+                                return;
+                        }
+
+                        if ( _autoReadEnabled && !_isListenerRegistered )
+                        {
+                                if ( AddClipboardFormatListener ( _hwndSource.Handle ) )
+                                {
+                                        _isListenerRegistered = true;
+                                        _logger.LogInformation ( "Clipboard listener registered." );
+                                }
+                                else
+                                {
+                                        _logger.LogWarning ( "Failed to register clipboard listener." );
+                                }
+                        }
+                        else if ( !_autoReadEnabled && _isListenerRegistered )
+                        {
+                                RemoveClipboardListener ( );
+                        }
+                }
+
+                private void RemoveClipboardListener ( )
+                {
+                        if ( _hwndSource == null )
+                                return;
+
+                        if ( RemoveClipboardFormatListener ( _hwndSource.Handle ) )
+                        {
+                                _logger.LogInformation ( "Clipboard listener unregistered." );
+                        }
+                        else
+                        {
+                                _logger.LogWarning ( "Failed to unregister clipboard listener." );
+                        }
+
+                        _isListenerRegistered = false;
+                }
+
+                private IntPtr WndProc ( IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled )
+                {
+                        if ( msg == WindowsMessages.ClipboardUpdate && _autoReadEnabled )
+                        {
+                                try
+                                {
+                                        var clipboardText = GetValidatedClipboardText ( );
+                                        if ( !string.IsNullOrEmpty ( clipboardText ) )
+                                        {
+                                                ClipboardTextReady?.Invoke ( this, clipboardText );
+                                        }
+                                }
+                                catch ( Exception ex )
+                                {
+                                        _logger.LogError ( ex, "Error processing clipboard update." );
+                                }
+                        }
+
+                        return IntPtr.Zero;
+                }
+
+                private static string? SanitizeClipboardText ( string? text )
+                {
+                        if ( string.IsNullOrWhiteSpace ( text ) )
+                                return null;
+
+                        var sanitized = Regex.Replace ( text, "\\s+", " " ).Trim ( );
+                        return string.IsNullOrEmpty ( sanitized ) ? null : sanitized;
+                }
+
+                [DllImport ( "user32.dll", SetLastError = true )]
+                [return: MarshalAs ( UnmanagedType.Bool )]
+                private static extern bool AddClipboardFormatListener ( IntPtr hwnd );
+
+                [DllImport ( "user32.dll", SetLastError = true )]
+                [return: MarshalAs ( UnmanagedType.Bool )]
+                private static extern bool RemoveClipboardFormatListener ( IntPtr hwnd );
+        }
 }

--- a/Dissonance/Dissonance/Managers/HotkeyManager .cs
+++ b/Dissonance/Dissonance/Managers/HotkeyManager .cs
@@ -1,4 +1,6 @@
-﻿using Dissonance.Services.HotkeyService;
+using System;
+
+using Dissonance.Services.HotkeyService;
 using Dissonance.Services.SettingsService;
 using Dissonance.Services.TTSService;
 
@@ -6,75 +8,99 @@ using Microsoft.Extensions.Logging;
 
 namespace Dissonance.Managers
 {
-	public class HotkeyManager
-	{
-		private readonly ClipboardManager _clipboardManager;
-		private readonly IHotkeyService _hotkeyService;
-		private readonly ILogger<HotkeyManager> _logger;
-		private readonly ISettingsService _settingsService;
-		private readonly ITTSService _ttsService;
-		private bool _isSpeaking;
+        public class HotkeyManager : IDisposable
+        {
+                private readonly ClipboardManager _clipboardManager;
+                private readonly IHotkeyService _hotkeyService;
+                private readonly ILogger<HotkeyManager> _logger;
+                private readonly ISettingsService _settingsService;
+                private readonly ITTSService _ttsService;
+                private bool _isSpeaking;
 
-		public HotkeyManager ( IHotkeyService hotkeyService, ISettingsService settingsService, ITTSService ttsService, ClipboardManager clipboardManager, ILogger<HotkeyManager> logger )
-		{
-			_hotkeyService = hotkeyService ?? throw new ArgumentNullException ( nameof ( hotkeyService ) );
-			_settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
-			_ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
-			_clipboardManager = clipboardManager ?? throw new ArgumentNullException ( nameof ( clipboardManager ) );
-			_logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
-			_ttsService.SpeechCompleted += OnSpeechCompleted;
-		}
+                public HotkeyManager ( IHotkeyService hotkeyService, ISettingsService settingsService, ITTSService ttsService, ClipboardManager clipboardManager, ILogger<HotkeyManager> logger )
+                {
+                        _hotkeyService = hotkeyService ?? throw new ArgumentNullException ( nameof ( hotkeyService ) );
+                        _settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
+                        _ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
+                        _clipboardManager = clipboardManager ?? throw new ArgumentNullException ( nameof ( clipboardManager ) );
+                        _logger = logger ?? throw new ArgumentNullException ( nameof ( logger ) );
+                        _ttsService.SpeechCompleted += OnSpeechCompleted;
+                        _clipboardManager.ClipboardTextReady += OnClipboardTextReady;
+                }
 
-		private void OnHotkeyPressed ( )
-		{
-			if ( _isSpeaking )
-			{
-				_ttsService.Stop ( );
-				_isSpeaking = false;
-				_logger.LogInformation ( "TTS playback stopped." );
-				return;
-			}
+                public void Initialize ( MainWindow mainWindow )
+                {
+                        _hotkeyService.Initialize ( mainWindow );
+                        var settings = _settingsService.GetCurrentSettings();
 
-			var clipboardText = _clipboardManager.GetValidatedClipboardText();
-			if ( !string.IsNullOrEmpty ( clipboardText ) )
-			{
-				var settings = _settingsService.GetCurrentSettings();
-				_ttsService.SetTTSParameters ( settings.Voice, settings.VoiceRate, settings.Volume );
-				_ttsService.Speak ( clipboardText );
-				_isSpeaking = true;
-				_logger.LogInformation ( $"Speaking clipboard text: {clipboardText}" );
-			}
-			else
-			{
-				_logger.LogWarning ( "Clipboard is empty or contains invalid text." );
-			}
-		}
+                        _hotkeyService.RegisterHotkey ( new AppSettings.HotkeySettings
+                        {
+                                Modifiers = settings.Hotkey.Modifiers,
+                                Key = settings.Hotkey.Key
+                        } );
 
-		private void OnSpeechCompleted ( object sender, EventArgs e )
-		{
-			_isSpeaking = false;
-			_logger.LogInformation ( "TTS playback completed." );
-		}
+                        _hotkeyService.HotkeyPressed += OnHotkeyPressed;
+                        _logger.LogInformation ( "HotkeyManager initialized and hotkey registered." );
+                }
 
-		public void Dispose ( )
-		{
-			_hotkeyService.Dispose ( );
-			_logger.LogInformation ( "HotkeyManager disposed." );
-		}
+                public void Dispose ( )
+                {
+                        _hotkeyService.HotkeyPressed -= OnHotkeyPressed;
+                        _clipboardManager.ClipboardTextReady -= OnClipboardTextReady;
+                        _ttsService.SpeechCompleted -= OnSpeechCompleted;
+                        _hotkeyService.Dispose ( );
+                        _logger.LogInformation ( "HotkeyManager disposed." );
+                }
 
-		public void Initialize ( MainWindow mainWindow )
-		{
-			_hotkeyService.Initialize ( mainWindow );
-			var settings = _settingsService.GetCurrentSettings();
+                private void OnHotkeyPressed ( )
+                {
+                        if ( _isSpeaking )
+                        {
+                                _ttsService.Stop ( );
+                                _isSpeaking = false;
+                                _logger.LogInformation ( "TTS playback stopped." );
+                                return;
+                        }
 
-			_hotkeyService.RegisterHotkey ( new AppSettings.HotkeySettings
-			{
-				Modifiers = settings.Hotkey.Modifiers,
-				Key = settings.Hotkey.Key
-			} );
+                        SpeakClipboardContents ( );
+                }
 
-			_hotkeyService.HotkeyPressed += OnHotkeyPressed;
-			_logger.LogInformation ( "HotkeyManager initialized and hotkey registered." );
-		}
-	}
+                private void OnClipboardTextReady ( object? sender, string clipboardText )
+                {
+                        if ( _isSpeaking )
+                        {
+                                _logger.LogInformation ( "Skipping automatic clipboard read because speech is already in progress." );
+                                return;
+                        }
+
+                        StartSpeaking ( clipboardText, "clipboard" );
+                }
+
+                private void OnSpeechCompleted ( object sender, EventArgs e )
+                {
+                        _isSpeaking = false;
+                        _logger.LogInformation ( "TTS playback completed." );
+                }
+
+                private void SpeakClipboardContents ( )
+                {
+                        var clipboardText = _clipboardManager.GetValidatedClipboardText();
+                        if ( string.IsNullOrEmpty ( clipboardText ) )
+                        {
+                                _logger.LogWarning ( "Clipboard is empty or contains invalid text." );
+                                return;
+                        }
+
+                        StartSpeaking ( clipboardText, "hotkey" );
+                }
+
+                private void StartSpeaking ( string clipboardText, string source )
+                {
+                        var settings = _settingsService.GetCurrentSettings();
+                        _ttsService.SetTTSParameters ( settings.Voice, settings.VoiceRate, settings.Volume );
+                        _ttsService.Speak ( clipboardText );
+                        _isSpeaking = true;
+                        _logger.LogInformation ( "Speaking clipboard text triggered by {Source}.", source );
+                }
+        }
 }

--- a/Dissonance/Dissonance/Managers/StartupManager .cs
+++ b/Dissonance/Dissonance/Managers/StartupManager .cs
@@ -34,11 +34,14 @@ namespace Dissonance.Managers
 		{
 			if ( mainWindow == null ) throw new ArgumentNullException ( nameof ( mainWindow ) );
 
-			mainWindow.Loaded += ( s, e ) =>
-			{
-				var hotkeyManager = _serviceProvider.GetRequiredService<HotkeyManager>();
-				hotkeyManager.Initialize ( mainWindow );
-			};
+                        mainWindow.Loaded += ( s, e ) =>
+                        {
+                                var clipboardManager = _serviceProvider.GetRequiredService<ClipboardManager>();
+                                clipboardManager.Initialize ( mainWindow );
+
+                                var hotkeyManager = _serviceProvider.GetRequiredService<HotkeyManager>();
+                                hotkeyManager.Initialize ( mainWindow );
+                        };
 
 			_logger.LogInformation ( "StartupManager subscribed to MainWindow Loaded event." );
 		}

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -176,7 +176,7 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = null,
                                 WindowHeight = null,
                                 IsWindowMaximized = false,
-                                Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E" },
+                                Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
                         };
                 }
 
@@ -198,6 +198,7 @@ namespace Dissonance.Services.SettingsService
                                 {
                                         Modifiers = settings.Hotkey?.Modifiers ?? string.Empty,
                                         Key = settings.Hotkey?.Key ?? string.Empty,
+                                        AutoReadClipboard = settings.Hotkey?.AutoReadClipboard ?? false,
                                 }
                         };
                 }
@@ -224,6 +225,7 @@ namespace Dissonance.Services.SettingsService
                                 {
                                         Modifiers = string.IsNullOrWhiteSpace ( settings.Hotkey?.Modifiers ) ? reference.Hotkey.Modifiers : settings.Hotkey.Modifiers,
                                         Key = string.IsNullOrWhiteSpace ( settings.Hotkey?.Key ) ? reference.Hotkey.Key : settings.Hotkey.Key,
+                                        AutoReadClipboard = settings.Hotkey?.AutoReadClipboard ?? reference.Hotkey.AutoReadClipboard,
                                 }
                         };
 

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -159,6 +159,12 @@
                                    Style="{StaticResource CardTitleTextStyle}"/>
                         <TextBlock Text="Define the shortcut that instantly voices your clipboard."
                                    Style="{StaticResource CardDescriptionTextStyle}"/>
+                        <CheckBox Content="Automatically speak new clipboard text"
+                                  IsChecked="{Binding AutoReadClipboard, Mode=TwoWay}"
+                                  Margin="0,12,0,0"
+                                  AutomationProperties.Name="Automatically speak new clipboard text"
+                                  AutomationProperties.HelpText="When enabled, clipboard text will be spoken immediately after it changes"
+                                  TabIndex="5"/>
                         <StackPanel Orientation="Horizontal">
                             <TextBox x:Name="ReadClipboardHotkeyTextBox"
                                      Style="{StaticResource ModernTextBoxStyle}"
@@ -166,7 +172,7 @@
                                      AutomationProperties.LabeledBy="{Binding ElementName=HotkeyHeading}"
                                      ToolTip="Set the hotkey used to trigger speaking the clipboard's text"
                                      Width="170"
-                                     TabIndex="5"
+                                     TabIndex="6"
                                      IsReadOnly="True"
                                      PreviewKeyDown="ReadClipboardHotkeyTextBox_PreviewKeyDown"
                                      AutomationProperties.HelpText="Specify the key combination that will read clipboard contents"/>
@@ -176,7 +182,7 @@
                                     Margin="12,0,0,0"
                                     MinWidth="72"
                                     ToolTip="Apply the new hotkey immediately"
-                                    TabIndex="6"
+                                    TabIndex="7"
                                     AutomationProperties.Name="Apply hotkey"
                                     AutomationProperties.HelpText="Applies the entered hotkey combination"/>
                         </StackPanel>


### PR DESCRIPTION
## Summary
- persist an AutoReadClipboard option across settings import/export and expose it in the main window
- hook the clipboard manager into WM_CLIPBOARDUPDATE and publish sanitized clipboard text when auto-read is enabled
- let the hotkey manager consume clipboard events while preventing overlapping playback and initialize managers from StartupManager

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f8feeaa4832d965010f8bdcc61f6