### PR TITLE
Add manual clipboard narration controls

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -203,13 +203,14 @@ namespace Dissonance.Tests.ViewModels
                         var messageService = new FakeMessageService();
                         var clipboardService = new TestClipboardService();
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>());
+                        var hotkeyManager = new HotkeyManager(hotkeyService, settingsService, ttsService, clipboardManager, new TestLogger<HotkeyManager>());
 
-                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager);
+                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, hotkeyManager);
 
-                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager);
+                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager, hotkeyManager);
                 }
 
-                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager);
+                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager, HotkeyManager HotkeyManager);
 
                 private sealed class TestSettingsService : ISettingsService
                 {

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -18,6 +18,14 @@
         Foreground="{DynamicResource PrimaryForegroundBrush}"
         FontFamily="{DynamicResource BaseFontFamily}"
         d:DataContext="{d:DesignInstance Type=local:MainWindowViewModel}">
+    <Window.InputBindings>
+        <KeyBinding Key="S"
+                    Modifiers="Control,Shift"
+                    Command="{Binding SpeakClipboardCommand}"/>
+        <KeyBinding Key="X"
+                    Modifiers="Control,Shift"
+                    Command="{Binding StopSpeechCommand}"/>
+    </Window.InputBindings>
     <shell:WindowChrome.WindowChrome>
         <shell:WindowChrome CaptionHeight="0"
                              CornerRadius="0"
@@ -316,6 +324,49 @@
                                               TabIndex="5"/>
                             </Grid>
                         </Border>
+
+                        <StackPanel Margin="0,16,0,0">
+                            <TextBlock Text="Manual narration controls"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                            <StackPanel Orientation="Horizontal"
+                                        Margin="0,8,0,0"
+                                        HorizontalAlignment="Left">
+                                <Button Content="Speak clipboard now"
+                                        Style="{StaticResource PrimaryButtonStyle}"
+                                        Command="{Binding SpeakClipboardCommand}"
+                                        MinWidth="190"
+                                        MinHeight="44"
+                                        Padding="18,10"
+                                        AutomationProperties.Name="Speak clipboard now"
+                                        AutomationProperties.HelpText="Copies the current selection if available, or uses the clipboard contents, and speaks it aloud"
+                                        ToolTip="Copy the current selection and start narration"
+                                        TabIndex="8">
+                                    <Button.InputBindings>
+                                        <KeyBinding Key="S"
+                                                    Modifiers="Control,Shift"
+                                                    Command="{Binding SpeakClipboardCommand}"/>
+                                    </Button.InputBindings>
+                                </Button>
+                                <Button Content="Stop narration"
+                                        Style="{StaticResource PrimaryButtonStyle}"
+                                        Command="{Binding StopSpeechCommand}"
+                                        Margin="12,0,0,0"
+                                        MinWidth="160"
+                                        MinHeight="44"
+                                        Padding="18,10"
+                                        AutomationProperties.Name="Stop narration"
+                                        AutomationProperties.HelpText="Stop the current clipboard narration immediately"
+                                        ToolTip="Stop speaking clipboard text"
+                                        TabIndex="9">
+                                    <Button.InputBindings>
+                                        <KeyBinding Key="X"
+                                                    Modifiers="Control,Shift"
+                                                    Command="{Binding StopSpeechCommand}"/>
+                                    </Button.InputBindings>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
 
                         <Border Margin="0,16,0,0"
                                 Padding="10"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -20,10 +20,10 @@
         d:DataContext="{d:DesignInstance Type=local:MainWindowViewModel}">
     <Window.InputBindings>
         <KeyBinding Key="S"
-                    Modifiers="Control,Shift"
+                    Modifiers="Control+Shift"
                     Command="{Binding SpeakClipboardCommand}"/>
         <KeyBinding Key="X"
-                    Modifiers="Control,Shift"
+                    Modifiers="Control+Shift"
                     Command="{Binding StopSpeechCommand}"/>
     </Window.InputBindings>
     <shell:WindowChrome.WindowChrome>


### PR DESCRIPTION
## Summary
- expose new HotkeyManager helpers and state change events so clipboard narration can be triggered outside the global shortcut
- add Speak/Stop commands to MainWindowViewModel that coordinate with the hotkey pipeline and surface messaging when nothing can be narrated
- surface accessible clipboard narration buttons and accelerator keys on the main window

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1216b776c832d935fccfc00735930