### PR TITLE
Add manual speech section

### DIFF
--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -24,6 +24,8 @@ namespace Dissonance
 
                 public bool IsWindowMaximized { get; set; }
 
+                public string ManualSpeechLastInput { get; set; } = string.Empty;
+
                 public class HotkeySettings
                 {
                         public string Key { get; set; }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -176,6 +176,7 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = null,
                                 WindowHeight = null,
                                 IsWindowMaximized = false,
+                                ManualSpeechLastInput = string.Empty,
                                 Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
                         };
                 }
@@ -194,6 +195,7 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = settings.WindowWidth,
                                 WindowHeight = settings.WindowHeight,
                                 IsWindowMaximized = settings.IsWindowMaximized,
+                                ManualSpeechLastInput = settings.ManualSpeechLastInput ?? string.Empty,
                                 Hotkey = new HotkeySettings
                                 {
                                         Modifiers = settings.Hotkey?.Modifiers ?? string.Empty,
@@ -221,6 +223,7 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = NormalizeDimension ( settings.WindowWidth, reference.WindowWidth ),
                                 WindowHeight = NormalizeDimension ( settings.WindowHeight, reference.WindowHeight ),
                                 IsWindowMaximized = settings.IsWindowMaximized,
+                                ManualSpeechLastInput = settings.ManualSpeechLastInput ?? reference.ManualSpeechLastInput,
                                 Hotkey = new HotkeySettings
                                 {
                                         Modifiers = string.IsNullOrWhiteSpace ( settings.Hotkey?.Modifiers ) ? reference.Hotkey.Modifiers : settings.Hotkey.Modifiers,

--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -35,6 +35,7 @@ namespace Dissonance.ViewModels
                 private readonly ClipboardManager _clipboardManager;
                 private readonly Dispatcher _dispatcher;
                 private readonly ObservableCollection<NavigationSectionViewModel> _navigationSections = new ObservableCollection<NavigationSectionViewModel> ( );
+                private readonly ManualSpeechViewModel _manualSpeechViewModel;
                 private bool _isDarkTheme;
                 private bool _isNavigationMenuOpen;
                 private string _hotkeyCombination = string.Empty;
@@ -109,6 +110,8 @@ namespace Dissonance.ViewModels
                         OnPropertyChanged ( nameof ( CurrentThemeName ) );
                         OnPropertyChanged ( nameof ( SaveConfigAsDefaultOnClose ) );
 
+                        _manualSpeechViewModel = new ManualSpeechViewModel ( _ttsService, _settingsService );
+
                         _navigationSections.Add ( new NavigationSectionViewModel (
                                 "clipboard-reader",
                                 "Clipboard Reader",
@@ -117,6 +120,14 @@ namespace Dissonance.ViewModels
                                 "Fine-tune speech playback, volume, and shortcuts for the clipboard narration experience.",
                                 this,
                                 showSettingsControls: true ) );
+
+                        _navigationSections.Add ( new NavigationSectionViewModel (
+                                "manual-speech",
+                                "Manual Speech",
+                                "Type anything you'd like Dissonance to say and play it on demand.",
+                                "Manual Speech",
+                                "Compose custom narration and trigger speech immediately whenever you need it.",
+                                _manualSpeechViewModel ) );
                 }
 
                 public event PropertyChangedEventHandler PropertyChanged;

--- a/Dissonance/Dissonance/ViewModels/ManualSpeechViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/ManualSpeechViewModel.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+
+using Dissonance.Infrastructure.Commands;
+using Dissonance.Services.SettingsService;
+using Dissonance.Services.TTSService;
+
+namespace Dissonance.ViewModels
+{
+        public class ManualSpeechViewModel : INotifyPropertyChanged, INotifyDataErrorInfo
+        {
+                private readonly ITTSService _ttsService;
+                private readonly ISettingsService _settingsService;
+                private readonly RelayCommand _speakInputCommand;
+                private readonly RelayCommandNoParam _clearInputCommand;
+                private readonly Dictionary<string, List<string>> _propertyErrors = new Dictionary<string, List<string>> ( StringComparer.Ordinal );
+                private string _inputText;
+
+                public ManualSpeechViewModel ( ITTSService ttsService, ISettingsService settingsService )
+                {
+                        _ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
+                        _settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
+
+                        var settings = _settingsService.GetCurrentSettings ( );
+                        _inputText = settings?.ManualSpeechLastInput ?? string.Empty;
+                        ValidateInput ( );
+
+                        _speakInputCommand = new RelayCommand ( _ => SpeakInputInternal ( ), _ => CanSpeak );
+                        _clearInputCommand = new RelayCommandNoParam ( ClearInput, ( ) => !string.IsNullOrWhiteSpace ( InputText ) );
+                }
+
+                public event PropertyChangedEventHandler? PropertyChanged;
+
+                public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+                public string InputText
+                {
+                        get => _inputText;
+                        set
+                        {
+                                if ( _inputText == value )
+                                        return;
+
+                                _inputText = value ?? string.Empty;
+                                OnPropertyChanged ( nameof ( InputText ) );
+                                ValidateInput ( );
+                                _speakInputCommand.RaiseCanExecuteChanged ( );
+                                _clearInputCommand.RaiseCanExecuteChanged ( );
+                                OnPropertyChanged ( nameof ( CanSpeak ) );
+                                OnPropertyChanged ( nameof ( InputValidationMessage ) );
+                        }
+                }
+
+                public bool CanSpeak => !string.IsNullOrWhiteSpace ( InputText );
+
+                public string InputValidationMessage
+                {
+                        get
+                        {
+                                if ( _propertyErrors.TryGetValue ( nameof ( InputText ), out var errors ) && errors.Any ( ) )
+                                        return errors[0];
+
+                                return string.Empty;
+                        }
+                }
+
+                public ICommand SpeakInputCommand => _speakInputCommand;
+
+                public ICommand ClearInputCommand => _clearInputCommand;
+
+                public bool HasErrors => _propertyErrors.Count > 0;
+
+                public IEnumerable GetErrors ( string? propertyName )
+                {
+                        if ( string.IsNullOrWhiteSpace ( propertyName ) )
+                                return _propertyErrors.SelectMany ( kvp => kvp.Value );
+
+                        if ( _propertyErrors.TryGetValue ( propertyName, out var errors ) )
+                                return errors;
+
+                        return Array.Empty<string> ( );
+                }
+
+                private void SpeakInputInternal ( )
+                {
+                        var textToSpeak = InputText?.Trim ( );
+                        if ( string.IsNullOrWhiteSpace ( textToSpeak ) )
+                                return;
+
+                        _ttsService.Stop ( );
+                        _ttsService.Speak ( textToSpeak );
+                        PersistInput ( textToSpeak );
+                }
+
+                private void ClearInput ( )
+                {
+                        if ( string.IsNullOrEmpty ( InputText ) )
+                                return;
+
+                        InputText = string.Empty;
+                        PersistInput ( string.Empty );
+                }
+
+                private void PersistInput ( string text )
+                {
+                        var settings = _settingsService.GetCurrentSettings ( );
+                        if ( settings == null )
+                                return;
+
+                        if ( string.Equals ( settings.ManualSpeechLastInput, text, StringComparison.Ordinal ) )
+                                return;
+
+                        settings.ManualSpeechLastInput = text;
+                        _settingsService.SaveCurrentSettings ( );
+                }
+
+                private void ValidateInput ( )
+                {
+                        var errors = new List<string> ( );
+                        if ( string.IsNullOrWhiteSpace ( InputText ) )
+                        {
+                                errors.Add ( "Enter text to speak." );
+                        }
+
+                        UpdateErrors ( nameof ( InputText ), errors );
+                }
+
+                private void UpdateErrors ( string propertyName, List<string> errors )
+                {
+                        var hasExistingErrors = _propertyErrors.TryGetValue ( propertyName, out var existingErrors );
+                        var existingErrorsList = hasExistingErrors && existingErrors != null ? existingErrors : Array.Empty<string> ( );
+                        var hasNewErrors = errors.Count > 0;
+
+                        if ( !hasNewErrors )
+                        {
+                                if ( hasExistingErrors )
+                                        _propertyErrors.Remove ( propertyName );
+                        }
+                        else
+                        {
+                                _propertyErrors[propertyName] = errors;
+                        }
+
+                        if ( hasExistingErrors != hasNewErrors || ( hasNewErrors && !existingErrorsList.SequenceEqual ( errors ) ) )
+                        {
+                                ErrorsChanged?.Invoke ( this, new DataErrorsChangedEventArgs ( propertyName ) );
+                                OnPropertyChanged ( nameof ( InputValidationMessage ) );
+                                OnPropertyChanged ( nameof ( HasErrors ) );
+                        }
+                }
+
+                private void OnPropertyChanged ( string propertyName )
+                {
+                        PropertyChanged?.Invoke ( this, new PropertyChangedEventArgs ( propertyName ) );
+                }
+        }
+}

--- a/Dissonance/Dissonance/Windows/Controls/ManualSpeechView.xaml
+++ b/Dissonance/Dissonance/Windows/Controls/ManualSpeechView.xaml
@@ -1,0 +1,84 @@
+<UserControl x:Class="Dissonance.Windows.Controls.ManualSpeechView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Dissonance.ViewModels"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=viewModels:ManualSpeechViewModel}">
+    <UserControl.Resources>
+        <Style x:Key="ManualSpeechSecondaryButtonStyle"
+               TargetType="Button"
+               BasedOn="{StaticResource PrimaryButtonStyle}">
+            <Setter Property="Background" Value="{DynamicResource SurfaceBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+        </Style>
+    </UserControl.Resources>
+    <Grid Margin="0,0,0,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock x:Name="ManualSpeechLabel"
+                       Text="Manual speech input"
+                       Style="{StaticResource CardTitleTextStyle}"
+                       AutomationProperties.Name="Manual speech input" />
+            <TextBlock Text="Type or paste any text and select Speak to hear it immediately."
+                       Style="{StaticResource CardDescriptionTextStyle}" />
+        </StackPanel>
+        <Border Grid.Row="1"
+                BorderBrush="{DynamicResource CardBorderBrush}"
+                BorderThickness="1"
+                Background="{DynamicResource SurfaceBackgroundBrush}">
+            <TextBox x:Name="ManualSpeechTextBox"
+                     Text="{Binding InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     MinHeight="160"
+                     Padding="12"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Disabled"
+                     AutomationProperties.LabeledBy="{Binding ElementName=ManualSpeechLabel}"
+                     AutomationProperties.HelpText="Enter the text you want to hear read aloud"
+                     SpellCheck.IsEnabled="True" />
+        </Border>
+        <StackPanel Grid.Row="2"
+                    Orientation="Vertical"
+                    Margin="0,12,0,0">
+            <TextBlock Text="{Binding InputValidationMessage, TargetNullValue=''}"
+                       Margin="0,0,0,12"
+                       Foreground="{DynamicResource AccentBrush}">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <Trigger Property="Text" Value="">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Speak"
+                        Command="{Binding SpeakInputCommand}"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        MinWidth="96"
+                        Margin="0,0,8,0"
+                        AutomationProperties.Name="Speak manual input"
+                        AutomationProperties.HelpText="Play the text you've typed"
+                        IsEnabled="{Binding CanSpeak}" />
+                <Button Content="Clear"
+                        Command="{Binding ClearInputCommand}"
+                        Style="{StaticResource ManualSpeechSecondaryButtonStyle}"
+                        MinWidth="96"
+                        AutomationProperties.Name="Clear manual input"
+                        AutomationProperties.HelpText="Remove all text from the manual speech box" />
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Dissonance/Dissonance/Windows/Controls/ManualSpeechView.xaml.cs
+++ b/Dissonance/Dissonance/Windows/Controls/ManualSpeechView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace Dissonance.Windows.Controls
+{
+        public partial class ManualSpeechView : UserControl
+        {
+                public ManualSpeechView ( )
+                {
+                        InitializeComponent ( );
+                }
+        }
+}

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:Dissonance.ViewModels"
+        xmlns:controls="clr-namespace:Dissonance.Windows.Controls"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
         mc:Ignorable="d"
         Title="Dissonance"
@@ -75,6 +76,9 @@
         </Style>
         <DataTemplate DataType="{x:Type local:NavigationSectionViewModel}">
             <ContentPresenter Content="{Binding ContentViewModel}"/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type local:ManualSpeechViewModel}">
+            <controls:ManualSpeechView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type local:MainWindowViewModel}">
             <Grid>


### PR DESCRIPTION
## Summary
- add a manual speech view model with validation and TTS commands
- create a manual speech view and wire it into the navigation templates
- persist the last manual speech entry through the settings service

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e122752014832dade12cca4b6f2c9d