### PR TITLE
Add document reader service and navigation section

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Speech.Synthesis;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Dissonance;
 using Dissonance.Managers;
 using Dissonance.Services.ClipboardService;
+using Dissonance.Services.DocumentService;
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.MessageService;
 using Dissonance.Services.SettingsService;
@@ -201,15 +204,17 @@ namespace Dissonance.Tests.ViewModels
                         var hotkeyService = new TestHotkeyService();
                         var themeService = new TestThemeService();
                         var messageService = new FakeMessageService();
+                        var documentTextExtractor = new TestDocumentTextExtractor();
                         var clipboardService = new TestClipboardService();
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>());
 
-                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager);
+                        var documentReaderViewModel = new DocumentReaderViewModel(documentTextExtractor, messageService, settingsService, ttsService);
+                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, documentReaderViewModel);
 
-                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager);
+                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager, documentReaderViewModel);
                 }
 
-                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager);
+                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager, DocumentReaderViewModel DocumentReaderViewModel);
 
                 private sealed class TestSettingsService : ISettingsService
                 {
@@ -345,6 +350,16 @@ namespace Dissonance.Tests.ViewModels
                         public void ApplyTheme(AppTheme theme)
                         {
                                 CurrentTheme = theme;
+                        }
+                }
+
+                private sealed class TestDocumentTextExtractor : IDocumentTextExtractor
+                {
+                        public IReadOnlyCollection<string> SupportedFileExtensions { get; } = new[] { ".txt", ".rtf", ".docx" };
+
+                        public Task<string?> ExtractTextAsync(string filePath, CancellationToken cancellationToken = default)
+                        {
+                                return Task.FromResult<string?>("test document");
                         }
                 }
 

--- a/Dissonance/Dissonance/App.xaml.cs
+++ b/Dissonance/Dissonance/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using Dissonance.Infrastructure.Logging;
 using Dissonance.Managers;
 using Dissonance.Services.ClipboardService;
+using Dissonance.Services.DocumentService;
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.MessageService;
 using Dissonance.Services.SettingsService;
@@ -37,6 +38,8 @@ namespace Dissonance
                         services.AddSingleton<IThemeService, ThemeService> ( );
                         services.AddSingleton<IHotkeyService, HotkeyService> ( );
                         services.AddSingleton<IMessageService, MessageService> ( );
+                        services.AddSingleton<IDocumentTextExtractor, DocumentTextExtractor> ( );
+                        services.AddSingleton<DocumentReaderViewModel> ( );
                         services.AddSingleton<ClipboardManager> ( );
                         services.AddSingleton<HotkeyManager> ( );
                         services.AddSingleton<StartupManager> ( );

--- a/Dissonance/Dissonance/Infrastructure/Constants/MessageBoxTitles.cs
+++ b/Dissonance/Dissonance/Infrastructure/Constants/MessageBoxTitles.cs
@@ -9,5 +9,7 @@ public const string HotkeyServiceWarning = "Hotkey Service Warning";
     public const string SettingsServiceInfo = "Settings Service";
 public const string TTSServiceError = "TTS Service Failure";
 public const string TTSServiceWarning = "TTS Service Warning";
+    public const string DocumentServiceError = "Document Reader Error";
+    public const string DocumentServiceWarning = "Document Reader";
 }
 }

--- a/Dissonance/Dissonance/Services/DocumentService/DocumentTextExtractor.cs
+++ b/Dissonance/Dissonance/Services/DocumentService/DocumentTextExtractor.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using System.Xml.Linq;
+
+namespace Dissonance.Services.DocumentService
+{
+        internal class DocumentTextExtractor : IDocumentTextExtractor
+        {
+                private static readonly IReadOnlyCollection<string> SupportedExtensions = new[] { ".txt", ".rtf", ".docx" };
+                private static readonly XNamespace WordNamespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+                public IReadOnlyCollection<string> SupportedFileExtensions => SupportedExtensions;
+
+                public Task<string?> ExtractTextAsync ( string filePath, CancellationToken cancellationToken = default )
+                {
+                        if ( string.IsNullOrWhiteSpace ( filePath ) )
+                                throw new ArgumentException ( "File path cannot be null or whitespace.", nameof ( filePath ) );
+
+                        return Task.Run ( ( ) => ExtractTextInternal ( filePath, cancellationToken ), cancellationToken );
+                }
+
+                private static string? ExtractTextInternal ( string filePath, CancellationToken cancellationToken )
+                {
+                        cancellationToken.ThrowIfCancellationRequested ( );
+
+                        var extension = Path.GetExtension ( filePath )?.ToLowerInvariant ( );
+                        if ( extension == null || !SupportedExtensions.Contains ( extension ) )
+                                throw new NotSupportedException ( $"Files with extension '{extension}' are not supported." );
+
+                        return extension switch
+                        {
+                                ".txt" => ReadPlainText ( filePath, cancellationToken ),
+                                ".rtf" => ReadRichText ( filePath, cancellationToken ),
+                                ".docx" => ReadWordDocument ( filePath, cancellationToken ),
+                                _ => throw new NotSupportedException ( $"Files with extension '{extension}' are not supported." ),
+                        };
+                }
+
+                private static string? ReadPlainText ( string filePath, CancellationToken cancellationToken )
+                {
+                        using var stream = new FileStream ( filePath, FileMode.Open, FileAccess.Read, FileShare.Read );
+                        using var reader = new StreamReader ( stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true );
+                        var text = reader.ReadToEnd ( );
+                        cancellationToken.ThrowIfCancellationRequested ( );
+                        return Sanitize ( text );
+                }
+
+                private static string? ReadRichText ( string filePath, CancellationToken cancellationToken )
+                {
+                        string? result = null;
+                        Exception? failure = null;
+
+                        var thread = new Thread ( ( ) =>
+                        {
+                                try
+                                {
+                                        using var stream = new FileStream ( filePath, FileMode.Open, FileAccess.Read, FileShare.Read );
+                                        var flowDocument = new FlowDocument ( );
+                                        var textRange = new TextRange ( flowDocument.ContentStart, flowDocument.ContentEnd );
+                                        textRange.Load ( stream, DataFormats.Rtf );
+                                        result = textRange.Text;
+                                }
+                                catch ( Exception ex )
+                                {
+                                        failure = ex;
+                                }
+                        } )
+                        {
+                                IsBackground = true
+                        };
+
+                        thread.SetApartmentState ( ApartmentState.STA );
+                        thread.Start ( );
+                        thread.Join ( );
+
+                        cancellationToken.ThrowIfCancellationRequested ( );
+
+                        if ( failure != null )
+                                throw failure;
+
+                        return Sanitize ( result );
+                }
+
+                private static string? ReadWordDocument ( string filePath, CancellationToken cancellationToken )
+                {
+                        using var stream = new FileStream ( filePath, FileMode.Open, FileAccess.Read, FileShare.Read );
+                        using var archive = new ZipArchive ( stream, ZipArchiveMode.Read, leaveOpen: false );
+                        var entry = archive.GetEntry ( "word/document.xml" );
+                        if ( entry == null )
+                                return null;
+
+                        using var entryStream = entry.Open ( );
+                        var document = XDocument.Load ( entryStream, LoadOptions.PreserveWhitespace );
+                        cancellationToken.ThrowIfCancellationRequested ( );
+
+                        var sb = new StringBuilder ( );
+                        foreach ( var paragraph in document.Descendants ( WordNamespace + "p" ) )
+                        {
+                                var paragraphText = string.Concat ( paragraph
+                                        .Descendants ( WordNamespace + "t" )
+                                        .Select ( t => t.Value ) );
+
+                                if ( string.IsNullOrWhiteSpace ( paragraphText ) )
+                                        continue;
+
+                                if ( sb.Length > 0 )
+                                        sb.Append ( ' ' );
+
+                                sb.Append ( paragraphText );
+                        }
+
+                        return Sanitize ( sb.ToString ( ) );
+                }
+
+                private static string? Sanitize ( string? text )
+                {
+                        if ( string.IsNullOrWhiteSpace ( text ) )
+                                return null;
+
+                        var sanitized = Regex.Replace ( text, "\\s+", " " ).Trim ( );
+                        return string.IsNullOrEmpty ( sanitized ) ? null : sanitized;
+                }
+        }
+}

--- a/Dissonance/Dissonance/Services/DocumentService/IDocumentTextExtractor.cs
+++ b/Dissonance/Dissonance/Services/DocumentService/IDocumentTextExtractor.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dissonance.Services.DocumentService
+{
+        public interface IDocumentTextExtractor
+        {
+                IReadOnlyCollection<string> SupportedFileExtensions { get; }
+
+                Task<string?> ExtractTextAsync ( string filePath, CancellationToken cancellationToken = default );
+        }
+}

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -1,0 +1,573 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+using Dissonance.Infrastructure.Commands;
+using Dissonance.Infrastructure.Constants;
+using Dissonance.Services.DocumentService;
+using Dissonance.Services.MessageService;
+using Dissonance.Services.SettingsService;
+using Dissonance.Services.TTSService;
+
+using Microsoft.Win32;
+
+namespace Dissonance.ViewModels
+{
+        public class DocumentReaderViewModel : INotifyPropertyChanged
+        {
+                private const int SegmentCharacterLimit = 1200;
+                private readonly IDocumentTextExtractor _documentTextExtractor;
+                private readonly IMessageService _messageService;
+                private readonly ISettingsService _settingsService;
+                private readonly ITTSService _ttsService;
+                private readonly Dispatcher _dispatcher;
+                private readonly RelayCommand _browseForFileCommand;
+                private readonly RelayCommand _readDocumentCommand;
+                private readonly RelayCommand _stopReadingCommand;
+                private readonly RelayCommand _clearDocumentCommand;
+                private CancellationTokenSource? _loadCancellation;
+                private string? _documentText;
+                private string? _selectedFileName;
+                private string? _documentPreview;
+                private string? _documentDetails;
+                private string _statusMessage = "Drop a document or browse to get started.";
+                private bool _isBusy;
+                private bool _isDropActive;
+                private bool _isReading;
+                private IReadOnlyList<string> _segments = Array.Empty<string> ( );
+                private int _currentSegmentIndex = -1;
+                private int _completedSegments;
+
+                public DocumentReaderViewModel (
+                        IDocumentTextExtractor documentTextExtractor,
+                        IMessageService messageService,
+                        ISettingsService settingsService,
+                        ITTSService ttsService )
+                {
+                        _documentTextExtractor = documentTextExtractor ?? throw new ArgumentNullException ( nameof ( documentTextExtractor ) );
+                        _messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
+                        _settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
+                        _ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
+
+                        _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+                        _ttsService.SpeechCompleted += OnSpeechCompleted;
+
+                        _browseForFileCommand = new RelayCommand ( _ => BrowseForFile ( ), _ => !IsBusy );
+                        _readDocumentCommand = new RelayCommand ( _ => StartReading ( ), _ => CanStartReading ( ) );
+                        _stopReadingCommand = new RelayCommand ( _ => StopReading ( ), _ => IsReading );
+                        _clearDocumentCommand = new RelayCommand ( _ => ClearDocument ( ), _ => CanClearDocument ( ) );
+                }
+
+                public event PropertyChangedEventHandler? PropertyChanged;
+
+                public ICommand BrowseForFileCommand => _browseForFileCommand;
+
+                public ICommand ReadDocumentCommand => _readDocumentCommand;
+
+                public ICommand StopReadingCommand => _stopReadingCommand;
+
+                public ICommand ClearDocumentCommand => _clearDocumentCommand;
+
+                public string SupportedFormatsDescription => string.Join ( ", ", _documentTextExtractor.SupportedFileExtensions.Select ( ext => ext.TrimStart ( '.' ).ToUpperInvariant ( ) ) );
+
+                public string? SelectedFileName
+                {
+                        get => _selectedFileName;
+                        private set
+                        {
+                                if ( _selectedFileName == value )
+                                        return;
+
+                                _selectedFileName = value;
+                                OnPropertyChanged ( nameof ( SelectedFileName ) );
+                        }
+                }
+
+                public string? DocumentPreview
+                {
+                        get => _documentPreview;
+                        private set
+                        {
+                                if ( _documentPreview == value )
+                                        return;
+
+                                _documentPreview = value;
+                                OnPropertyChanged ( nameof ( DocumentPreview ) );
+                        }
+                }
+
+                public string? DocumentDetails
+                {
+                        get => _documentDetails;
+                        private set
+                        {
+                                if ( _documentDetails == value )
+                                        return;
+
+                                _documentDetails = value;
+                                OnPropertyChanged ( nameof ( DocumentDetails ) );
+                        }
+                }
+
+                public string StatusMessage
+                {
+                        get => _statusMessage;
+                        private set
+                        {
+                                if ( _statusMessage == value )
+                                        return;
+
+                                _statusMessage = value;
+                                OnPropertyChanged ( nameof ( StatusMessage ) );
+                        }
+                }
+
+                public bool IsBusy
+                {
+                        get => _isBusy;
+                        private set
+                        {
+                                if ( _isBusy == value )
+                                        return;
+
+                                _isBusy = value;
+                                OnPropertyChanged ( nameof ( IsBusy ) );
+                                OnPropertyChanged ( nameof ( ProgressLabel ) );
+                                OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                                UpdateCommandStates ( );
+                        }
+                }
+
+                public bool IsDropActive
+                {
+                        get => _isDropActive;
+                        set
+                        {
+                                if ( _isDropActive == value )
+                                        return;
+
+                                _isDropActive = value;
+                                OnPropertyChanged ( nameof ( IsDropActive ) );
+                        }
+                }
+
+                public bool HasDocument => !string.IsNullOrEmpty ( _documentText );
+
+                public bool IsReading
+                {
+                        get => _isReading;
+                        private set
+                        {
+                                if ( _isReading == value )
+                                        return;
+
+                                _isReading = value;
+                                OnPropertyChanged ( nameof ( IsReading ) );
+                                OnPropertyChanged ( nameof ( ProgressLabel ) );
+                                OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                                UpdateCommandStates ( );
+                        }
+                }
+
+                public int TotalSegments => _segments.Count;
+
+                public double ReadingProgress => TotalSegments == 0 ? 0 : ( double ) _completedSegments / TotalSegments;
+
+                public string ProgressLabel
+                {
+                        get
+                        {
+                                if ( IsBusy )
+                                        return "Loading document...";
+
+                                if ( TotalSegments == 0 )
+                                        return "No document loaded";
+
+                                if ( !IsReading && _completedSegments == 0 )
+                                        return "Ready to read";
+
+                                if ( _completedSegments >= TotalSegments )
+                                        return "Playback finished";
+
+                                var currentSegmentNumber = Math.Max ( 1, _currentSegmentIndex + 1 );
+                                return $"Segment {currentSegmentNumber} of {TotalSegments}";
+                        }
+                }
+
+                public bool IsProgressVisible => IsBusy || IsReading || _completedSegments > 0;
+
+                public void OnWindowClosing ( )
+                {
+                        CancelOngoingLoad ( );
+                        StopReading ( );
+                }
+
+                public async Task IngestDataObjectAsync ( IDataObject? dataObject )
+                {
+                        if ( dataObject == null )
+                                return;
+
+                        if ( !dataObject.GetDataPresent ( DataFormats.FileDrop ) )
+                        {
+                                _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "Please drop document files only." );
+                                return;
+                        }
+
+                        if ( dataObject.GetData ( DataFormats.FileDrop ) is not string[] files || files.Length == 0 )
+                        {
+                                _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "No files were provided." );
+                                return;
+                        }
+
+                        var file = files.FirstOrDefault ( IsSupportedFile );
+                        if ( string.IsNullOrEmpty ( file ) )
+                        {
+                                _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "No supported documents were found in the drop." );
+                                return;
+                        }
+
+                        await LoadDocumentAsync ( file );
+                }
+
+                public bool CanAcceptDataObject ( IDataObject? dataObject )
+                {
+                        if ( dataObject == null || !dataObject.GetDataPresent ( DataFormats.FileDrop ) )
+                                return false;
+
+                        if ( dataObject.GetData ( DataFormats.FileDrop ) is not string[] files || files.Length == 0 )
+                                return false;
+
+                        return files.Any ( IsSupportedFile );
+                }
+
+                public async Task LoadDocumentAsync ( string filePath )
+                {
+                        if ( string.IsNullOrWhiteSpace ( filePath ) )
+                                return;
+
+                        if ( !File.Exists ( filePath ) )
+                        {
+                                _messageService.DissonanceMessageBoxShowError ( MessageBoxTitles.DocumentServiceError, $"The file '{filePath}' could not be found." );
+                                return;
+                        }
+
+                        if ( !IsSupportedFile ( filePath ) )
+                        {
+                                _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "Only .TXT, .RTF, or .DOCX files are supported." );
+                                return;
+                        }
+
+                        CancelOngoingLoad ( );
+                        var cancellation = new CancellationTokenSource ( );
+                        _loadCancellation = cancellation;
+
+                        try
+                        {
+                                IsBusy = true;
+                                StatusMessage = $"Loading {Path.GetFileName ( filePath )}...";
+
+                                var sanitizedText = await _documentTextExtractor.ExtractTextAsync ( filePath, cancellation.Token );
+
+                                if ( cancellation.IsCancellationRequested )
+                                        return;
+
+                                if ( string.IsNullOrEmpty ( sanitizedText ) )
+                                {
+                                        _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "The selected file did not contain readable text." );
+                                        ResetDocumentState ( );
+                                        StatusMessage = "The selected file did not contain readable text.";
+                                        return;
+                                }
+
+                                ApplyLoadedDocument ( filePath, sanitizedText );
+                        }
+                        catch ( OperationCanceledException )
+                        {
+                                // Loading was cancelled intentionally.
+                        }
+                        catch ( Exception ex )
+                        {
+                                _messageService.DissonanceMessageBoxShowError ( MessageBoxTitles.DocumentServiceError, $"Failed to read '{Path.GetFileName ( filePath )}'.", ex );
+                                ResetDocumentState ( );
+                                StatusMessage = "Unable to load the selected document.";
+                        }
+                        finally
+                        {
+                                if ( ReferenceEquals ( _loadCancellation, cancellation ) )
+                                {
+                                        _loadCancellation.Dispose ( );
+                                        _loadCancellation = null;
+                                }
+
+                                IsBusy = false;
+                        }
+                }
+
+                public void ClearDocument ( )
+                {
+                        if ( !HasDocument )
+                                return;
+
+                        StopReadingInternal ( true );
+                        ResetDocumentState ( );
+                        StatusMessage = "Document cleared.";
+                }
+
+                public void StopReading ( )
+                {
+                        if ( !IsReading )
+                                return;
+
+                        StopReadingInternal ( true );
+                        StatusMessage = "Playback stopped.";
+                }
+
+                private void ApplyLoadedDocument ( string filePath, string sanitizedText )
+                {
+                        StopReadingInternal ( false );
+
+                        _documentText = sanitizedText;
+                        SelectedFileName = Path.GetFileName ( filePath );
+
+                        var previewLength = Math.Min ( 800, sanitizedText.Length );
+                        DocumentPreview = previewLength == sanitizedText.Length
+                                ? sanitizedText
+                                : sanitizedText[..previewLength] + "…";
+
+                        var wordCount = sanitizedText.Split ( new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries ).Length;
+                        DocumentDetails = string.Format ( CultureInfo.CurrentCulture, "{0:N0} words • {1:N0} characters", wordCount, sanitizedText.Length );
+
+                        _segments = SegmentDocument ( sanitizedText );
+                        _currentSegmentIndex = -1;
+                        _completedSegments = 0;
+                        OnPropertyChanged ( nameof ( TotalSegments ) );
+                        OnPropertyChanged ( nameof ( HasDocument ) );
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+                        OnPropertyChanged ( nameof ( IsProgressVisible ) );
+
+                        StatusMessage = TotalSegments > 0
+                                ? "Document loaded. Ready to read."
+                                : "Document loaded, but nothing to read.";
+
+                        UpdateCommandStates ( );
+                }
+
+                private void StartReading ( )
+                {
+                        if ( !CanStartReading ( ) )
+                                return;
+
+                        if ( TotalSegments == 0 )
+                        {
+                                _messageService.DissonanceMessageBoxShowWarning ( MessageBoxTitles.DocumentServiceWarning, "The document does not contain readable content." );
+                                return;
+                        }
+
+                        var settings = _settingsService.GetCurrentSettings ( );
+                        _ttsService.SetTTSParameters ( settings.Voice, settings.VoiceRate, settings.Volume );
+
+                        _completedSegments = 0;
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+                        OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                        SpeakSegment ( 0 );
+                }
+
+                private void SpeakSegment ( int index )
+                {
+                        if ( index < 0 || index >= TotalSegments )
+                                return;
+
+                        _currentSegmentIndex = index;
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+
+                        var segmentText = _segments[index];
+                        StatusMessage = $"Reading segment {index + 1} of {TotalSegments}...";
+                        IsReading = true;
+
+                        var prompt = _ttsService.Speak ( segmentText );
+                        if ( prompt == null )
+                        {
+                                IsReading = false;
+                                StatusMessage = "Unable to start playback.";
+                                return;
+                        }
+
+                        UpdateCommandStates ( );
+                }
+
+                private void StopReadingInternal ( bool stopSynthesizer, bool resetProgress = true )
+                {
+                        if ( stopSynthesizer )
+                        {
+                                try
+                                {
+                                        _ttsService.Stop ( );
+                                }
+                                catch
+                                {
+                                        // The service already reports errors; swallow here to avoid duplicate messaging.
+                                }
+                        }
+
+                        _currentSegmentIndex = -1;
+                        if ( resetProgress )
+                                _completedSegments = 0;
+                        IsReading = false;
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+                        OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                }
+
+                private void ResetDocumentState ( )
+                {
+                        _documentText = null;
+                        SelectedFileName = null;
+                        DocumentPreview = null;
+                        DocumentDetails = null;
+                        _segments = Array.Empty<string> ( );
+                        _currentSegmentIndex = -1;
+                        _completedSegments = 0;
+                        OnPropertyChanged ( nameof ( HasDocument ) );
+                        OnPropertyChanged ( nameof ( TotalSegments ) );
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+                        OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                        StatusMessage = "Drop a document or browse to get started.";
+                        UpdateCommandStates ( );
+                }
+
+                private bool CanStartReading ( ) => HasDocument && !IsBusy && !IsReading;
+
+                private bool CanClearDocument ( ) => HasDocument && !IsBusy;
+
+                private void CancelOngoingLoad ( )
+                {
+                        if ( _loadCancellation == null )
+                                return;
+
+                        if ( !_loadCancellation.IsCancellationRequested )
+                        {
+                                _loadCancellation.Cancel ( );
+                        }
+
+                        _loadCancellation.Dispose ( );
+                        _loadCancellation = null;
+                }
+
+                private bool IsSupportedFile ( string filePath )
+                {
+                        var extension = Path.GetExtension ( filePath )?.ToLowerInvariant ( );
+                        return extension != null && _documentTextExtractor.SupportedFileExtensions.Contains ( extension );
+                }
+
+                private static IReadOnlyList<string> SegmentDocument ( string text )
+                {
+                        if ( string.IsNullOrWhiteSpace ( text ) )
+                                return Array.Empty<string> ( );
+
+                        var segments = new List<string> ( );
+                        var words = text.Split ( ' ' );
+                        var builder = new List<string> ( );
+                        var currentLength = 0;
+
+                        foreach ( var word in words )
+                        {
+                                if ( string.IsNullOrWhiteSpace ( word ) )
+                                        continue;
+
+                                var candidateLength = currentLength + ( currentLength == 0 ? 0 : 1 ) + word.Length;
+                                if ( candidateLength > SegmentCharacterLimit && builder.Count > 0 )
+                                {
+                                        segments.Add ( string.Join ( " ", builder ) );
+                                        builder.Clear ( );
+                                        currentLength = 0;
+                                }
+
+                                builder.Add ( word );
+                                currentLength = currentLength == 0 ? word.Length : currentLength + 1 + word.Length;
+                        }
+
+                        if ( builder.Count > 0 )
+                        {
+                                segments.Add ( string.Join ( " ", builder ) );
+                        }
+
+                        return segments;
+                }
+
+                private void UpdateCommandStates ( )
+                {
+                        _browseForFileCommand.RaiseCanExecuteChanged ( );
+                        _readDocumentCommand.RaiseCanExecuteChanged ( );
+                        _stopReadingCommand.RaiseCanExecuteChanged ( );
+                        _clearDocumentCommand.RaiseCanExecuteChanged ( );
+                }
+
+                private void OnSpeechCompleted ( object? sender, System.Speech.Synthesis.SpeakCompletedEventArgs e )
+                {
+                        if ( !_dispatcher.CheckAccess ( ) )
+                        {
+                                _dispatcher.BeginInvoke ( new Action<object?, System.Speech.Synthesis.SpeakCompletedEventArgs> ( OnSpeechCompleted ), sender, e );
+                                return;
+                        }
+
+                        if ( !IsReading )
+                                return;
+
+                        if ( e.Cancelled )
+                        {
+                                StopReadingInternal ( false );
+                                StatusMessage = "Playback cancelled.";
+                                return;
+                        }
+
+                        _completedSegments++;
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+
+                        if ( _completedSegments >= TotalSegments )
+                        {
+                                StopReadingInternal ( false, resetProgress: false );
+                                StatusMessage = "Finished reading the document.";
+                                return;
+                        }
+
+                        var nextIndex = _completedSegments;
+                        SpeakSegment ( nextIndex );
+                        if ( !IsReading )
+                                return;
+                        OnPropertyChanged ( nameof ( ReadingProgress ) );
+                        OnPropertyChanged ( nameof ( ProgressLabel ) );
+                        OnPropertyChanged ( nameof ( IsProgressVisible ) );
+                }
+
+                private void BrowseForFile ( )
+                {
+                        var dialog = new OpenFileDialog
+                        {
+                                Filter = "Documents (*.txt;*.rtf;*.docx)|*.txt;*.rtf;*.docx",
+                                CheckFileExists = true,
+                                Title = "Select a document to read"
+                        };
+
+                        if ( dialog.ShowDialog ( ) == true )
+                        {
+                                _ = LoadDocumentAsync ( dialog.FileName );
+                        }
+                }
+
+                protected virtual void OnPropertyChanged ( string propertyName )
+                {
+                        PropertyChanged?.Invoke ( this, new PropertyChangedEventArgs ( propertyName ) );
+                }
+        }
+}

--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -33,6 +33,7 @@ namespace Dissonance.ViewModels
                 private readonly ITTSService _ttsService;
                 private readonly IThemeService _themeService;
                 private readonly ClipboardManager _clipboardManager;
+                private readonly DocumentReaderViewModel _documentReaderViewModel;
                 private readonly Dispatcher _dispatcher;
                 private readonly ObservableCollection<NavigationSectionViewModel> _navigationSections = new ObservableCollection<NavigationSectionViewModel> ( );
                 private bool _isDarkTheme;
@@ -49,7 +50,7 @@ namespace Dissonance.ViewModels
                 private Prompt? _activePreviewPrompt;
                 private bool _isPreviewing;
 
-                public MainWindowViewModel ( ISettingsService settingsService, ITTSService ttsService, IHotkeyService hotkeyService, IThemeService themeService, IMessageService messageService, ClipboardManager clipboardManager )
+                public MainWindowViewModel ( ISettingsService settingsService, ITTSService ttsService, IHotkeyService hotkeyService, IThemeService themeService, IMessageService messageService, ClipboardManager clipboardManager, DocumentReaderViewModel documentReaderViewModel )
                 {
                         _settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
                         _ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
@@ -57,6 +58,7 @@ namespace Dissonance.ViewModels
                         _themeService = themeService ?? throw new ArgumentNullException ( nameof ( themeService ) );
                         _messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
                         _clipboardManager = clipboardManager ?? throw new ArgumentNullException ( nameof ( clipboardManager ) );
+                        _documentReaderViewModel = documentReaderViewModel ?? throw new ArgumentNullException ( nameof ( documentReaderViewModel ) );
 
                         _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
 
@@ -117,6 +119,14 @@ namespace Dissonance.ViewModels
                                 "Fine-tune speech playback, volume, and shortcuts for the clipboard narration experience.",
                                 this,
                                 showSettingsControls: true ) );
+
+                        _navigationSections.Add ( new NavigationSectionViewModel (
+                                "document-reader",
+                                "Document Reader",
+                                "Drop a text, rich text, or Word document to have Dissonance narrate it.",
+                                "Document Reader",
+                                "Load longer documents and listen as Dissonance streams them in manageable segments.",
+                                _documentReaderViewModel ) );
                 }
 
                 public event PropertyChangedEventHandler PropertyChanged;
@@ -317,6 +327,7 @@ namespace Dissonance.ViewModels
 
                 public void OnWindowClosing ( )
                 {
+                        _documentReaderViewModel.OnWindowClosing ( );
                         _ttsService.SpeechCompleted -= OnSpeechCompleted;
                         SetPreviewState ( false, null );
                         _ttsService.Stop ( );

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:Dissonance.ViewModels"
+        xmlns:views="clr-namespace:Dissonance.Windows.Views"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
         mc:Ignorable="d"
         Title="Dissonance"
@@ -75,6 +76,9 @@
         </Style>
         <DataTemplate DataType="{x:Type local:NavigationSectionViewModel}">
             <ContentPresenter Content="{Binding ContentViewModel}"/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type local:DocumentReaderViewModel}">
+            <views:DocumentReaderView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type local:MainWindowViewModel}">
             <Grid>

--- a/Dissonance/Dissonance/Windows/Views/DocumentReaderView.xaml
+++ b/Dissonance/Dissonance/Windows/Views/DocumentReaderView.xaml
@@ -1,0 +1,168 @@
+<UserControl x:Class="Dissonance.Windows.Views.DocumentReaderView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Dissonance.ViewModels"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:DocumentReaderViewModel}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <Style x:Key="DropZoneButtonStyle" TargetType="Button">
+            <Setter Property="Padding" Value="24"/>
+            <Setter Property="Background" Value="{DynamicResource SurfaceBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="DropBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{StaticResource CardCornerRadius}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Stretch"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                                <Setter TargetName="DropBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="DropBorder" Property="Opacity" Value="0.6"/>
+                                <Setter Property="Cursor" Value="Arrow"/>
+                            </Trigger>
+                            <DataTrigger Binding="{Binding DataContext.IsDropActive, RelativeSource={RelativeSource TemplatedParent}}"
+                                         Value="True">
+                                <Setter TargetName="DropBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                                <Setter TargetName="DropBorder" Property="Background" Value="{DynamicResource ControlHoverBrush}"/>
+                            </DataTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Listen to your documents"
+                       Style="{StaticResource CardTitleTextStyle}"/>
+            <TextBlock Text="Drop a .TXT, .RTF, or .DOCX file below, or browse to select one."
+                       Margin="0,6,0,0"
+                       Style="{StaticResource CardDescriptionTextStyle}"/>
+        </StackPanel>
+
+        <Button x:Name="DropZoneButton"
+                Grid.Row="1"
+                Style="{StaticResource DropZoneButtonStyle}"
+                Command="{Binding BrowseForFileCommand}"
+                AllowDrop="True"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                VerticalContentAlignment="Center"
+                Focusable="True"
+                DragEnter="DropZoneButton_DragEnter"
+                DragOver="DropZoneButton_DragOver"
+                DragLeave="DropZoneButton_DragLeave"
+                Drop="DropZoneButton_Drop"
+                ToolTip="Drop a supported document or activate to browse for one">
+            <StackPanel>
+                <TextBlock Text="Drop document here or press Enter to browse"
+                           FontSize="16"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                <TextBlock Margin="0,4,0,0"
+                           Text="{Binding SupportedFormatsDescription, StringFormat=Supported formats: {0}}"
+                           Foreground="{DynamicResource SecondaryForegroundBrush}"
+                           TextWrapping="Wrap"/>
+                <StackPanel Margin="0,12,0,0"
+                            Orientation="Vertical">
+                    <TextBlock Text="{Binding SelectedFileName}" FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasDocument}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock Margin="0,4,0,0"
+                               Text="{Binding DocumentDetails}"
+                               Foreground="{DynamicResource SecondaryForegroundBrush}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasDocument}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </StackPanel>
+                <ProgressBar Margin="0,16,0,0"
+                             Height="6"
+                             Maximum="1"
+                             Value="{Binding ReadingProgress}"
+                             Visibility="{Binding IsProgressVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
+                             IsIndeterminate="{Binding IsBusy}"/>
+                <TextBlock Margin="0,8,0,0"
+                           Text="{Binding ProgressLabel}"
+                           Foreground="{DynamicResource SecondaryForegroundBrush}"
+                           Visibility="{Binding IsProgressVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <TextBlock Margin="0,12,0,0"
+                           Text="{Binding StatusMessage}"
+                           Foreground="{DynamicResource SecondaryForegroundBrush}"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+        </Button>
+
+        <StackPanel Grid.Row="2" Margin="0,20,0,0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                <Button Content="Read document"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        Command="{Binding ReadDocumentCommand}"
+                        Margin="0,0,12,0"/>
+                <Button Content="Stop"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        Command="{Binding StopReadingCommand}"
+                        Margin="0,0,12,0"/>
+                <Button Content="Clear"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        Command="{Binding ClearDocumentCommand}"/>
+            </StackPanel>
+
+            <TextBlock Margin="0,16,0,8"
+                       Text="Preview"
+                       FontWeight="SemiBold"
+                       Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+            <Border Background="{DynamicResource SurfaceBackgroundBrush}"
+                    BorderBrush="{DynamicResource CardBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource InputCornerRadius}"
+                    Padding="16"
+                    MinHeight="160">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <TextBlock Text="{Binding DocumentPreview, TargetNullValue=Drop a document to see a preview., FallbackValue=Drop a document to see a preview.}"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                </ScrollViewer>
+            </Border>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Dissonance/Dissonance/Windows/Views/DocumentReaderView.xaml.cs
+++ b/Dissonance/Dissonance/Windows/Views/DocumentReaderView.xaml.cs
@@ -1,0 +1,69 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+using Dissonance.ViewModels;
+
+namespace Dissonance.Windows.Views
+{
+        public partial class DocumentReaderView : UserControl
+        {
+                public DocumentReaderView ( )
+                {
+                        InitializeComponent ( );
+                }
+
+                private DocumentReaderViewModel? ViewModel => DataContext as DocumentReaderViewModel;
+
+                private void DropZoneButton_DragEnter ( object sender, DragEventArgs e )
+                {
+                        HandleDrag ( e );
+                }
+
+                private void DropZoneButton_DragOver ( object sender, DragEventArgs e )
+                {
+                        HandleDrag ( e );
+                }
+
+                private void DropZoneButton_DragLeave ( object sender, DragEventArgs e )
+                {
+                        if ( ViewModel != null )
+                        {
+                                ViewModel.IsDropActive = false;
+                        }
+                }
+
+                private async void DropZoneButton_Drop ( object sender, DragEventArgs e )
+                {
+                        if ( ViewModel == null )
+                                return;
+
+                        ViewModel.IsDropActive = false;
+
+                        if ( e.Data != null )
+                        {
+                                await ViewModel.IngestDataObjectAsync ( e.Data );
+                        }
+
+                        e.Handled = true;
+                }
+
+                private void HandleDrag ( DragEventArgs e )
+                {
+                        if ( ViewModel == null )
+                                return;
+
+                        if ( ViewModel.CanAcceptDataObject ( e.Data ) )
+                        {
+                                e.Handled = true;
+                                e.Effects = DragDropEffects.Copy;
+                                ViewModel.IsDropActive = true;
+                        }
+                        else
+                        {
+                                e.Effects = DragDropEffects.None;
+                                ViewModel.IsDropActive = false;
+                        }
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- add a document text extraction service that supports TXT, RTF, and DOCX inputs
- build a document reader view model and view with drag-and-drop ingestion, progress feedback, and TTS segment playback
- register the document reader in the main navigation and update dependency registration and tests accordingly

## Testing
- Not Run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1226f8364832da7cff937a8b10d80