### PR TITLE
Add document reader service and view model

### DIFF
--- a/Dissonance/Dissonance.Tests/Services/DocumentReaderServiceTests.cs
+++ b/Dissonance/Dissonance.Tests/Services/DocumentReaderServiceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+using Dissonance.Services.DocumentReader;
+
+using Xunit;
+
+namespace Dissonance.Tests.Services
+{
+        public class DocumentReaderServiceTests
+        {
+                [Fact]
+                public async Task ReadDocumentAsync_WithValidTextFile_ReturnsContent()
+                {
+                        var sampleText = "Hello world" + Environment.NewLine + "Second line";
+                        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+                        await File.WriteAllTextAsync(tempFile, sampleText);
+
+                        try
+                        {
+                                var service = new DocumentReaderService();
+                                var result = await service.ReadDocumentAsync(tempFile);
+
+                                Assert.Equal(tempFile, result.FilePath);
+                                Assert.Equal(sampleText, result.PlainText);
+                                Assert.Equal(4, result.WordCount);
+                                Assert.Equal(sampleText.Length, result.CharacterCount);
+                                Assert.IsType<FlowDocument>(result.Document);
+                                var paragraphs = result.Document.Blocks.OfType<Paragraph>().ToList();
+                                Assert.Equal(2, paragraphs.Count);
+                                Assert.Equal("Hello world", new TextRange(paragraphs[0].ContentStart, paragraphs[0].ContentEnd).Text.TrimEnd('\r', '\n'));
+                                Assert.Equal("Second line", new TextRange(paragraphs[1].ContentStart, paragraphs[1].ContentEnd).Text.TrimEnd('\r', '\n'));
+                        }
+                        finally
+                        {
+                                if (File.Exists(tempFile))
+                                {
+                                        File.Delete(tempFile);
+                                }
+                        }
+                }
+
+                [Fact]
+                public async Task ReadDocumentAsync_WithMissingFile_Throws()
+                {
+                        var service = new DocumentReaderService();
+                        await Assert.ThrowsAsync<FileNotFoundException>(() => service.ReadDocumentAsync("missing.txt"));
+                }
+
+                [Fact]
+                public async Task ReadDocumentAsync_WithUnsupportedExtension_Throws()
+                {
+                        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".rtf");
+                        await File.WriteAllTextAsync(tempFile, "sample");
+
+                        try
+                        {
+                                var service = new DocumentReaderService();
+                                await Assert.ThrowsAsync<NotSupportedException>(() => service.ReadDocumentAsync(tempFile));
+                        }
+                        finally
+                        {
+                                if (File.Exists(tempFile))
+                                {
+                                        File.Delete(tempFile);
+                                }
+                        }
+                }
+        }
+}

--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+using Dissonance.Services.DocumentReader;
+using Dissonance.ViewModels;
+
+using Xunit;
+
+namespace Dissonance.Tests.ViewModels
+{
+        public class DocumentReaderViewModelTests
+        {
+                [Fact]
+                public async Task LoadDocumentAsync_PopulatesPropertiesOnSuccess()
+                {
+                        var result = new DocumentReadResult("sample.txt", new FlowDocument(new Paragraph(new Run("Hello world"))), "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var viewModel = new DocumentReaderViewModel(service);
+
+                        var success = await viewModel.LoadDocumentAsync(result.FilePath);
+
+                        Assert.True(success);
+                        Assert.NotNull(viewModel.Document);
+                        Assert.Equal(result.PlainText, viewModel.PlainText);
+                        Assert.Equal(result.FilePath, viewModel.FilePath);
+                        Assert.Equal("sample.txt", viewModel.FileName);
+                        Assert.True(viewModel.IsDocumentLoaded);
+                        Assert.True(viewModel.CanReadDocument);
+                        Assert.Equal(2, viewModel.WordCount);
+                        Assert.Equal(result.PlainText.Length, viewModel.CharacterCount);
+                        Assert.Null(viewModel.StatusMessage);
+                        Assert.Null(viewModel.LastError);
+                        Assert.True(viewModel.ClearDocumentCommand.CanExecute(null));
+                }
+
+                [Fact]
+                public async Task LoadDocumentAsync_WhenServiceThrows_ReturnsFalseAndSetsError()
+                {
+                        var service = new FailingDocumentReaderService(new InvalidOperationException("boom"));
+                        var viewModel = new DocumentReaderViewModel(service);
+
+                        var success = await viewModel.LoadDocumentAsync("missing.txt");
+
+                        Assert.False(success);
+                        Assert.Null(viewModel.Document);
+                        Assert.Null(viewModel.PlainText);
+                        Assert.False(viewModel.IsDocumentLoaded);
+                        Assert.False(viewModel.CanReadDocument);
+                        Assert.Equal("boom", viewModel.StatusMessage);
+                        Assert.IsType<InvalidOperationException>(viewModel.LastError);
+                        Assert.False(viewModel.ClearDocumentCommand.CanExecute(null));
+                }
+
+                [Fact]
+                public void ClearDocumentCommand_ResetsState()
+                {
+                        var result = new DocumentReadResult("sample.txt", new FlowDocument(new Paragraph(new Run("Hello world"))), "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var viewModel = new DocumentReaderViewModel(service);
+
+                        viewModel.ClearDocumentCommand.Execute(null);
+
+                        Assert.Null(viewModel.Document);
+                        Assert.Null(viewModel.PlainText);
+                        Assert.Null(viewModel.FilePath);
+                        Assert.False(viewModel.IsDocumentLoaded);
+                        Assert.False(viewModel.ClearDocumentCommand.CanExecute(null));
+                }
+
+                private sealed class StubDocumentReaderService : IDocumentReaderService
+                {
+                        private readonly DocumentReadResult _result;
+
+                        public StubDocumentReaderService(DocumentReadResult result)
+                        {
+                                _result = result;
+                        }
+
+                        public Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+                        {
+                                return Task.FromResult(_result);
+                        }
+                }
+
+                private sealed class FailingDocumentReaderService : IDocumentReaderService
+                {
+                        private readonly Exception _exception;
+
+                        public FailingDocumentReaderService(Exception exception)
+                        {
+                                _exception = exception;
+                        }
+
+                        public Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+                        {
+                                return Task.FromException<DocumentReadResult>(_exception);
+                        }
+                }
+        }
+}

--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Speech.Synthesis;
+using System.Threading;
+using System.Windows.Documents;
 
 using Dissonance;
 using Dissonance.Managers;
 using Dissonance.Services.ClipboardService;
+using Dissonance.Services.DocumentReader;
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.MessageService;
 using Dissonance.Services.SettingsService;
@@ -204,14 +207,25 @@ namespace Dissonance.Tests.ViewModels
                         var messageService = new FakeMessageService();
                         var clipboardService = new TestClipboardService();
                         var statusService = new TestStatusAnnouncementService();
+                        var documentReaderService = new TestDocumentReaderService();
+                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService);
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>(), statusService);
 
-                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, statusService);
+                        var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, statusService, documentReaderViewModel);
 
-                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager, statusService);
+                        return new TestEnvironment(viewModel, settingsService, ttsService, hotkeyService, themeService, clipboardManager, statusService, documentReaderViewModel);
                 }
 
-                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager, TestStatusAnnouncementService StatusAnnouncementService);
+                private sealed record TestEnvironment(MainWindowViewModel ViewModel, TestSettingsService SettingsService, TestTtsService TtsService, TestHotkeyService HotkeyService, TestThemeService ThemeService, ClipboardManager ClipboardManager, TestStatusAnnouncementService StatusAnnouncementService, DocumentReaderViewModel DocumentReaderViewModel);
+
+                private sealed class TestDocumentReaderService : IDocumentReaderService
+                {
+                        public Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+                        {
+                                var document = new FlowDocument(new Paragraph(new Run("Sample")));
+                                return Task.FromResult(new DocumentReadResult(filePath, document, "Sample"));
+                        }
+                }
 
                 private sealed class TestStatusAnnouncementService : IStatusAnnouncementService
                 {

--- a/Dissonance/Dissonance/App.xaml.cs
+++ b/Dissonance/Dissonance/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using Dissonance.Infrastructure.Logging;
 using Dissonance.Managers;
 using Dissonance.Services.ClipboardService;
+using Dissonance.Services.DocumentReader;
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.MessageService;
 using Dissonance.Services.SettingsService;
@@ -34,6 +35,7 @@ namespace Dissonance
                 {
                         services.AddSingleton<ISettingsService, SettingsService> ( );
                         services.AddSingleton<IClipboardService, ClipboardService> ( );
+                        services.AddSingleton<IDocumentReaderService, DocumentReaderService> ( );
                         services.AddSingleton<ITTSService, TTSService> ( );
                         services.AddSingleton<IThemeService, ThemeService> ( );
                         services.AddSingleton<IStatusAnnouncementService, StatusAnnouncementService> ( );
@@ -42,6 +44,7 @@ namespace Dissonance
                         services.AddSingleton<ClipboardManager> ( );
                         services.AddSingleton<HotkeyManager> ( );
                         services.AddSingleton<StartupManager> ( );
+                        services.AddSingleton<DocumentReaderViewModel> ( );
                         services.AddSingleton<MainWindowViewModel> ( );
                         services.AddSingleton<MainWindow> ( );
                 }

--- a/Dissonance/Dissonance/Services/DocumentReader/DocumentReaderService.cs
+++ b/Dissonance/Dissonance/Services/DocumentReader/DocumentReaderService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+namespace Dissonance.Services.DocumentReader
+{
+        public class DocumentReaderService : IDocumentReaderService
+        {
+                public async Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+                {
+                        if (string.IsNullOrWhiteSpace(filePath))
+                                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+
+                        if (!File.Exists(filePath))
+                                throw new FileNotFoundException("The specified document could not be found.", filePath);
+
+                        var extension = Path.GetExtension(filePath);
+                        if (!string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase))
+                                throw new NotSupportedException($"The document type '{extension}' is not supported.");
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        string content;
+                        using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                        using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+                        {
+                                content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var document = CreateFlowDocument(content ?? string.Empty);
+                        return new DocumentReadResult(filePath, document, content ?? string.Empty);
+                }
+
+                private static FlowDocument CreateFlowDocument(string content)
+                {
+                        var document = new FlowDocument();
+                        if (string.IsNullOrEmpty(content))
+                        {
+                                document.Blocks.Add(new Paragraph(new Run(string.Empty)));
+                                return document;
+                        }
+
+                        var normalized = content.Replace("\r\n", "\n").Replace('\r', '\n');
+                        var lines = normalized.Split('\n');
+                        foreach (var line in lines)
+                        {
+                                document.Blocks.Add(new Paragraph(new Run(line)));
+                        }
+
+                        return document;
+                }
+        }
+}

--- a/Dissonance/Dissonance/Services/DocumentReader/IDocumentReaderService.cs
+++ b/Dissonance/Dissonance/Services/DocumentReader/IDocumentReaderService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+namespace Dissonance.Services.DocumentReader
+{
+        public interface IDocumentReaderService
+        {
+                Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default);
+        }
+
+        public sealed class DocumentReadResult
+        {
+                public DocumentReadResult(string filePath, FlowDocument document, string plainText)
+                {
+                        FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+                        Document = document ?? throw new ArgumentNullException(nameof(document));
+                        PlainText = plainText ?? string.Empty;
+                }
+
+                public string FilePath { get; }
+
+                public string FileName => Path.GetFileName(FilePath);
+
+                public FlowDocument Document { get; }
+
+                public string PlainText { get; }
+
+                public int CharacterCount => PlainText.Length;
+
+                public int WordCount
+                {
+                        get
+                        {
+                                if (string.IsNullOrWhiteSpace(PlainText))
+                                        return 0;
+
+                                var separators = new[] { ' ', '\t', '\r', '\n' };
+                                return PlainText
+                                        .Split(separators, StringSplitOptions.RemoveEmptyEntries)
+                                        .Length;
+                        }
+                }
+        }
+}

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -1,0 +1,206 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using System.Windows.Input;
+
+using Dissonance.Infrastructure.Commands;
+using Dissonance.Services.DocumentReader;
+
+namespace Dissonance.ViewModels
+{
+        public class DocumentReaderViewModel : INotifyPropertyChanged
+        {
+                private readonly IDocumentReaderService _documentReaderService;
+                private FlowDocument? _document;
+                private string? _plainText;
+                private string? _filePath;
+                private string? _statusMessage;
+                private bool _isBusy;
+                private Exception? _lastError;
+
+                public DocumentReaderViewModel(IDocumentReaderService documentReaderService)
+                {
+                        _documentReaderService = documentReaderService ?? throw new ArgumentNullException(nameof(documentReaderService));
+                        ClearDocumentCommand = new RelayCommandNoParam(ClearDocument, () => !IsBusy && (IsDocumentLoaded || HasStatusMessage));
+                }
+
+                public event PropertyChangedEventHandler? PropertyChanged;
+
+                public FlowDocument? Document
+                {
+                        get => _document;
+                        private set
+                        {
+                                if (ReferenceEquals(_document, value))
+                                        return;
+
+                                _document = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(IsDocumentLoaded));
+                                OnPropertyChanged(nameof(CanReadDocument));
+                                OnPropertyChanged(nameof(FileName));
+                                UpdateCommandStates();
+                        }
+                }
+
+                public string? PlainText
+                {
+                        get => _plainText;
+                        private set
+                        {
+                                if (_plainText == value)
+                                        return;
+
+                                _plainText = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(HasPlainText));
+                                OnPropertyChanged(nameof(WordCount));
+                                OnPropertyChanged(nameof(CharacterCount));
+                                OnPropertyChanged(nameof(CanReadDocument));
+                        }
+                }
+
+                public string? FilePath
+                {
+                        get => _filePath;
+                        private set
+                        {
+                                if (_filePath == value)
+                                        return;
+
+                                _filePath = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(FileName));
+                        }
+                }
+
+                public string? FileName => string.IsNullOrWhiteSpace(FilePath) ? null : Path.GetFileName(FilePath);
+
+                public bool IsDocumentLoaded => Document != null;
+
+                public bool HasPlainText => !string.IsNullOrWhiteSpace(PlainText);
+
+                public bool CanReadDocument => IsDocumentLoaded && HasPlainText;
+
+                public int WordCount => _plainText?.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length ?? 0;
+
+                public int CharacterCount => _plainText?.Length ?? 0;
+
+                public bool IsBusy
+                {
+                        get => _isBusy;
+                        private set
+                        {
+                                if (_isBusy == value)
+                                        return;
+
+                                _isBusy = value;
+                                OnPropertyChanged();
+                                UpdateCommandStates();
+                        }
+                }
+
+                public string? StatusMessage
+                {
+                        get => _statusMessage;
+                        private set
+                        {
+                                if (_statusMessage == value)
+                                        return;
+
+                                _statusMessage = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(HasStatusMessage));
+                                UpdateCommandStates();
+                        }
+                }
+
+                public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+                public Exception? LastError
+                {
+                        get => _lastError;
+                        private set
+                        {
+                                if (ReferenceEquals(_lastError, value))
+                                        return;
+
+                                _lastError = value;
+                                OnPropertyChanged();
+                        }
+                }
+
+                public ICommand ClearDocumentCommand { get; }
+
+                public async Task<bool> LoadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+                {
+                        if (string.IsNullOrWhiteSpace(filePath))
+                                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+
+                        try
+                        {
+                                IsBusy = true;
+                                LastError = null;
+                                StatusMessage = null;
+
+                                var result = await _documentReaderService.ReadDocumentAsync(filePath, cancellationToken).ConfigureAwait(false);
+
+                                ApplyResult(result);
+                                StatusMessage = null;
+                                return true;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                                ClearDocument();
+                                StatusMessage = "Document loading was canceled.";
+                                throw;
+                        }
+                        catch (Exception ex)
+                        {
+                                ClearDocument();
+                                LastError = ex;
+                                StatusMessage = ex.Message;
+                                return false;
+                        }
+                        finally
+                        {
+                                IsBusy = false;
+                        }
+                }
+
+                public void ClearDocument()
+                {
+                        Document = null;
+                        PlainText = null;
+                        FilePath = null;
+                        LastError = null;
+                        StatusMessage = null;
+                }
+
+                private void ApplyResult(DocumentReadResult result)
+                {
+                        if (result == null)
+                                throw new ArgumentNullException(nameof(result));
+
+                        Document = result.Document;
+                        PlainText = result.PlainText;
+                        FilePath = result.FilePath;
+                        LastError = null;
+                }
+
+                private void UpdateCommandStates()
+                {
+                        if (ClearDocumentCommand is RelayCommandNoParam clearCommand)
+                                clearCommand.RaiseCanExecuteChanged();
+                }
+
+                private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+                {
+                        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                }
+        }
+}

--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -39,6 +39,7 @@ namespace Dissonance.ViewModels
                 private readonly ObservableCollection<NavigationSectionViewModel> _navigationSections = new ObservableCollection<NavigationSectionViewModel> ( );
                 private readonly ObservableCollection<StatusAnnouncement> _statusHistory = new ObservableCollection<StatusAnnouncement> ( );
                 private readonly ReadOnlyObservableCollection<StatusAnnouncement> _statusHistoryView;
+                private readonly DocumentReaderViewModel _documentReaderViewModel;
                 private bool _isDarkTheme;
                 private bool _isNavigationMenuOpen;
                 private string _hotkeyCombination = string.Empty;
@@ -56,7 +57,7 @@ namespace Dissonance.ViewModels
 
                 private const int MaxStatusItems = 100;
 
-                public MainWindowViewModel ( ISettingsService settingsService, ITTSService ttsService, IHotkeyService hotkeyService, IThemeService themeService, IMessageService messageService, ClipboardManager clipboardManager, IStatusAnnouncementService statusAnnouncementService )
+                public MainWindowViewModel ( ISettingsService settingsService, ITTSService ttsService, IHotkeyService hotkeyService, IThemeService themeService, IMessageService messageService, ClipboardManager clipboardManager, IStatusAnnouncementService statusAnnouncementService, DocumentReaderViewModel documentReaderViewModel )
                 {
                         _settingsService = settingsService ?? throw new ArgumentNullException ( nameof ( settingsService ) );
                         _ttsService = ttsService ?? throw new ArgumentNullException ( nameof ( ttsService ) );
@@ -65,6 +66,7 @@ namespace Dissonance.ViewModels
                         _messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
                         _clipboardManager = clipboardManager ?? throw new ArgumentNullException ( nameof ( clipboardManager ) );
                         _statusAnnouncementService = statusAnnouncementService ?? throw new ArgumentNullException ( nameof ( statusAnnouncementService ) );
+                        _documentReaderViewModel = documentReaderViewModel ?? throw new ArgumentNullException ( nameof ( documentReaderViewModel ) );
 
                         _statusHistoryView = new ReadOnlyObservableCollection<StatusAnnouncement> ( _statusHistory );
 
@@ -144,6 +146,14 @@ namespace Dissonance.ViewModels
                                 "Fine-tune speech playback, volume, and shortcuts for the clipboard narration experience.",
                                 this,
                                 showSettingsControls: true ) );
+
+                        _navigationSections.Add ( new NavigationSectionViewModel (
+                                "document-reader",
+                                "Document Reader",
+                                "Load saved documents and prepare them for narration.",
+                                "Document Reader",
+                                "Open text files and review their contents before listening.",
+                                _documentReaderViewModel ) );
                 }
 
                 public event PropertyChangedEventHandler PropertyChanged;
@@ -151,6 +161,8 @@ namespace Dissonance.ViewModels
                 public ObservableCollection<string> AvailableVoices { get; } = new ObservableCollection<string> ( );
 
                 public ObservableCollection<NavigationSectionViewModel> NavigationSections => _navigationSections;
+
+                public DocumentReaderViewModel DocumentReader => _documentReaderViewModel;
 
                 public ReadOnlyObservableCollection<StatusAnnouncement> StatusHistory => _statusHistoryView;
 


### PR DESCRIPTION
## Summary
- add a document reader service and interface for loading text documents into FlowDocument results
- introduce a DocumentReaderViewModel with async loading/clear logic and expose it through the main window navigation
- add unit tests for the document reader service and view model while updating the main window view model tests for the new dependency

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e128670958832dbef88e616570af9e