### PR TITLE
Add playback controls to document reader

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -209,7 +209,7 @@ namespace Dissonance.Tests.ViewModels
                         var clipboardService = new TestClipboardService();
                         var statusService = new TestStatusAnnouncementService();
                         var documentReaderService = new TestDocumentReaderService();
-                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService);
+                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService, ttsService);
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>(), statusService);
 
                         var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, statusService, documentReaderViewModel);
@@ -332,6 +332,12 @@ namespace Dissonance.Tests.ViewModels
                         public Prompt? LastPrompt { get; private set; }
 
                         public event EventHandler<SpeakCompletedEventArgs>? SpeechCompleted
+                        {
+                                add { }
+                                remove { }
+                        }
+
+                        public event EventHandler<SpeakProgressEventArgs>? SpeechProgress
                         {
                                 add { }
                                 remove { }

--- a/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
@@ -12,5 +12,7 @@ namespace Dissonance.Services.TTSService
                 void Stop ( );
 
                 event EventHandler<SpeakCompletedEventArgs> SpeechCompleted;
+
+                event EventHandler<SpeakProgressEventArgs> SpeechProgress;
         }
 }

--- a/Dissonance/Dissonance/Services/TTSService/TTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/TTSService.cs
@@ -16,6 +16,7 @@ namespace Dissonance.Services.TTSService
                 private readonly SpeechSynthesizer _synthesizer;
 
                 public event EventHandler<SpeakCompletedEventArgs>? SpeechCompleted;
+                public event EventHandler<SpeakProgressEventArgs>? SpeechProgress;
 
                 public TTSService ( ILogger<TTSService> logger, IMessageService messageService )
                 {
@@ -23,6 +24,7 @@ namespace Dissonance.Services.TTSService
                         _messageService = messageService ?? throw new ArgumentNullException ( nameof ( messageService ) );
                         _synthesizer = new SpeechSynthesizer ( );
                         _synthesizer.SpeakCompleted += OnSpeakCompleted;
+                        _synthesizer.SpeakProgress += OnSpeakProgress;
                 }
 
                 public void SetTTSParameters ( string voice, double rate, int volume )
@@ -79,6 +81,11 @@ namespace Dissonance.Services.TTSService
                 private void OnSpeakCompleted ( object? sender, SpeakCompletedEventArgs e )
                 {
                         SpeechCompleted?.Invoke ( this, e );
+                }
+
+                private void OnSpeakProgress ( object? sender, SpeakProgressEventArgs e )
+                {
+                        SpeechProgress?.Invoke ( this, e );
                 }
         }
 }

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -2,13 +2,16 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Speech.Synthesis;
 
 using Dissonance.Infrastructure.Commands;
 using Dissonance.Services.DocumentReader;
+using Dissonance.Services.TTSService;
 
 using Microsoft.Win32;
 
@@ -19,18 +22,44 @@ namespace Dissonance.ViewModels
                 private readonly IDocumentReaderService _documentReaderService;
                 private readonly RelayCommandNoParam _clearDocumentCommand;
                 private readonly RelayCommandNoParam _browseForDocumentCommand;
+                private readonly RelayCommandNoParam _playPauseCommand;
+                private readonly RelayCommandNoParam _seekBackwardCommand;
+                private readonly RelayCommandNoParam _seekForwardCommand;
+                private readonly ITTSService _ttsService;
                 private FlowDocument? _document;
                 private string? _plainText;
                 private string? _filePath;
                 private string? _statusMessage;
                 private bool _isBusy;
                 private Exception? _lastError;
+                private Prompt? _currentPrompt;
+                private int _currentCharacterIndex;
+                private int _playbackStartCharacterIndex;
+                private TimeSpan _currentAudioPosition;
+                private TimeSpan _playbackStartAudioPosition;
+                private bool _isPlaying;
+                private bool _isPaused;
+                private bool _isStoppingForPause;
+                private bool _isStoppingForSeek;
+                private int? _pendingSeekCharacterIndex;
+                private TimeSpan _pendingSeekAudioPosition;
+                private double _charactersPerSecond;
+                private readonly List<(TimeSpan Time, int CharacterIndex)> _progressHistory = new();
 
-                public DocumentReaderViewModel(IDocumentReaderService documentReaderService)
+                private const double DefaultCharactersPerSecond = 15d;
+
+                public DocumentReaderViewModel(IDocumentReaderService documentReaderService, ITTSService ttsService)
                 {
                         _documentReaderService = documentReaderService ?? throw new ArgumentNullException(nameof(documentReaderService));
+                        _ttsService = ttsService ?? throw new ArgumentNullException(nameof(ttsService));
                         _clearDocumentCommand = new RelayCommandNoParam(ClearDocument, () => !IsBusy && (IsDocumentLoaded || HasStatusMessage));
                         _browseForDocumentCommand = new RelayCommandNoParam(BrowseForDocument, () => !IsBusy);
+                        _playPauseCommand = new RelayCommandNoParam(TogglePlayback, () => !IsBusy && CanReadDocument);
+                        _seekBackwardCommand = new RelayCommandNoParam(() => SeekBy(TimeSpan.FromSeconds(-10)), () => !IsBusy && CanReadDocument);
+                        _seekForwardCommand = new RelayCommandNoParam(() => SeekBy(TimeSpan.FromSeconds(10)), () => !IsBusy && CanReadDocument);
+
+                        _ttsService.SpeechCompleted += OnSpeechCompleted;
+                        _ttsService.SpeechProgress += OnSpeechProgress;
                 }
 
                 public event PropertyChangedEventHandler? PropertyChanged;
@@ -91,6 +120,62 @@ namespace Dissonance.ViewModels
 
                 public bool CanReadDocument => IsDocumentLoaded && HasPlainText;
 
+                public bool IsPlaying
+                {
+                        get => _isPlaying;
+                        private set
+                        {
+                                if (_isPlaying == value)
+                                        return;
+
+                                _isPlaying = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(PlayPauseLabel));
+                        }
+                }
+
+                public bool IsPaused
+                {
+                        get => _isPaused;
+                        private set
+                        {
+                                if (_isPaused == value)
+                                        return;
+
+                                _isPaused = value;
+                                OnPropertyChanged();
+                                OnPropertyChanged(nameof(PlayPauseLabel));
+                        }
+                }
+
+                public TimeSpan CurrentAudioPosition
+                {
+                        get => _currentAudioPosition;
+                        private set
+                        {
+                                if (_currentAudioPosition == value)
+                                        return;
+
+                                _currentAudioPosition = value;
+                                OnPropertyChanged();
+                        }
+                }
+
+                public int CurrentCharacterIndex
+                {
+                        get => _currentCharacterIndex;
+                        private set
+                        {
+                                if (_currentCharacterIndex == value)
+                                        return;
+
+                                _currentCharacterIndex = value;
+                                OnPropertyChanged();
+                        }
+                }
+
+                public string PlayPauseLabel => IsPlaying && !IsPaused ? "Pause" : "Play";
+
                 public int WordCount => _plainText?.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length ?? 0;
 
                 public int CharacterCount => _plainText?.Length ?? 0;
@@ -143,6 +228,12 @@ namespace Dissonance.ViewModels
 
                 public ICommand BrowseForDocumentCommand => _browseForDocumentCommand;
 
+                public ICommand PlayPauseCommand => _playPauseCommand;
+
+                public ICommand SeekBackwardCommand => _seekBackwardCommand;
+
+                public ICommand SeekForwardCommand => _seekForwardCommand;
+
                 public async Task<bool> LoadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
                 {
                         if (string.IsNullOrWhiteSpace(filePath))
@@ -186,6 +277,7 @@ namespace Dissonance.ViewModels
                         FilePath = null;
                         LastError = null;
                         StatusMessage = null;
+                        ResetPlaybackState();
                 }
 
                 private async void BrowseForDocument()
@@ -229,12 +321,16 @@ namespace Dissonance.ViewModels
                         PlainText = result.PlainText;
                         FilePath = result.FilePath;
                         LastError = null;
+                        ResetPlaybackState();
                 }
 
                 private void UpdateCommandStates()
                 {
                         _clearDocumentCommand.RaiseCanExecuteChanged();
                         _browseForDocumentCommand.RaiseCanExecuteChanged();
+                        _playPauseCommand.RaiseCanExecuteChanged();
+                        _seekBackwardCommand.RaiseCanExecuteChanged();
+                        _seekForwardCommand.RaiseCanExecuteChanged();
                 }
 
                 private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
@@ -259,6 +355,227 @@ namespace Dissonance.ViewModels
                         }
 
                         return document;
+                }
+
+                private void TogglePlayback()
+                {
+                        if (!CanReadDocument)
+                                return;
+
+                        if (!IsPlaying && !IsPaused)
+                        {
+                                StartPlaybackFromCurrentPosition();
+                                return;
+                        }
+
+                        if (IsPlaying && !IsPaused)
+                        {
+                                PausePlayback();
+                                return;
+                        }
+
+                        if (IsPaused)
+                        {
+                                StartPlaybackFromCurrentPosition();
+                        }
+                }
+
+                private void PausePlayback()
+                {
+                        if (_currentPrompt == null)
+                        {
+                                IsPlaying = false;
+                                IsPaused = true;
+                                return;
+                        }
+
+                        _isStoppingForPause = true;
+                        IsPlaying = false;
+                        IsPaused = true;
+                        _ttsService.Stop();
+                }
+
+                private void StartPlaybackFromCurrentPosition()
+                {
+                        if (PlainText == null)
+                                return;
+
+                        if (CurrentCharacterIndex >= PlainText.Length)
+                        {
+                                CurrentCharacterIndex = 0;
+                                CurrentAudioPosition = TimeSpan.Zero;
+                        }
+
+                        var remainingLength = PlainText.Length - CurrentCharacterIndex;
+                        if (remainingLength <= 0)
+                        {
+                                IsPlaying = false;
+                                IsPaused = false;
+                                return;
+                        }
+
+                        var textToSpeak = PlainText.Substring(CurrentCharacterIndex);
+                        _playbackStartCharacterIndex = CurrentCharacterIndex;
+                        _playbackStartAudioPosition = EstimateTimeFromCharacterIndex(CurrentCharacterIndex);
+                        _currentPrompt = _ttsService.Speak(textToSpeak);
+                        _pendingSeekCharacterIndex = null;
+                        _pendingSeekAudioPosition = TimeSpan.Zero;
+
+                        if (_currentPrompt != null)
+                        {
+                                IsPlaying = true;
+                                IsPaused = false;
+                                _isStoppingForPause = false;
+                                _isStoppingForSeek = false;
+                        }
+                        else
+                        {
+                                IsPlaying = false;
+                                IsPaused = false;
+                        }
+                }
+
+                private void SeekBy(TimeSpan offset)
+                {
+                        if (!CanReadDocument || PlainText == null)
+                                return;
+
+                        var seconds = offset.TotalSeconds;
+                        if (Math.Abs(seconds) < double.Epsilon)
+                                return;
+
+                        var cps = _charactersPerSecond > 0 ? _charactersPerSecond : DefaultCharactersPerSecond;
+                        if (cps <= 0)
+                                cps = DefaultCharactersPerSecond;
+
+                        var deltaChars = (int)Math.Round(cps * seconds);
+                        if (deltaChars == 0)
+                                deltaChars = seconds > 0 ? 1 : -1;
+
+                        var targetIndex = Math.Clamp(CurrentCharacterIndex + deltaChars, 0, PlainText.Length);
+                        var targetTime = EstimateTimeFromCharacterIndex(targetIndex);
+
+                        CurrentCharacterIndex = targetIndex;
+                        CurrentAudioPosition = targetTime;
+
+                        if (IsPlaying)
+                        {
+                                _pendingSeekCharacterIndex = targetIndex;
+                                _pendingSeekAudioPosition = targetTime;
+                                _isStoppingForSeek = true;
+                                IsPlaying = false;
+                                _ttsService.Stop();
+                        }
+                }
+
+                private void ResetPlaybackState()
+                {
+                        if (_currentPrompt != null)
+                                _ttsService.Stop();
+
+                        _currentPrompt = null;
+                        _playbackStartCharacterIndex = 0;
+                        _playbackStartAudioPosition = TimeSpan.Zero;
+                        _charactersPerSecond = 0;
+                        _progressHistory.Clear();
+                        _isStoppingForPause = false;
+                        _isStoppingForSeek = false;
+                        _pendingSeekCharacterIndex = null;
+                        _pendingSeekAudioPosition = TimeSpan.Zero;
+                        CurrentCharacterIndex = 0;
+                        CurrentAudioPosition = TimeSpan.Zero;
+                        IsPlaying = false;
+                        IsPaused = false;
+                }
+
+                private TimeSpan EstimateTimeFromCharacterIndex(int characterIndex)
+                {
+                        if (_progressHistory.Count > 0)
+                        {
+                                for (var i = _progressHistory.Count - 1; i >= 0; i--)
+                                {
+                                        var entry = _progressHistory[i];
+                                        if (entry.CharacterIndex <= characterIndex)
+                                        {
+                                                var cps = _charactersPerSecond > 0 ? _charactersPerSecond : DefaultCharactersPerSecond;
+                                                var delta = characterIndex - entry.CharacterIndex;
+                                                var additional = cps > 0 ? TimeSpan.FromSeconds(delta / cps) : TimeSpan.Zero;
+                                                return entry.Time + additional;
+                                        }
+                                }
+                        }
+
+                        if (_charactersPerSecond > 0)
+                                return TimeSpan.FromSeconds(characterIndex / _charactersPerSecond);
+
+                        return TimeSpan.FromSeconds(characterIndex / DefaultCharactersPerSecond);
+                }
+
+                private void OnSpeechProgress(object? sender, SpeakProgressEventArgs e)
+                {
+                        if (PlainText == null)
+                                return;
+
+                        var updatedIndex = _playbackStartCharacterIndex + e.CharacterPosition;
+                        if (updatedIndex > PlainText.Length)
+                                updatedIndex = PlainText.Length;
+
+                        if (updatedIndex > CurrentCharacterIndex)
+                                CurrentCharacterIndex = updatedIndex;
+
+                        var updatedTime = _playbackStartAudioPosition + e.AudioPosition;
+                        if (updatedTime > CurrentAudioPosition)
+                                CurrentAudioPosition = updatedTime;
+
+                        if (updatedTime.TotalSeconds > 0)
+                                _charactersPerSecond = Math.Max(_charactersPerSecond, CurrentCharacterIndex / updatedTime.TotalSeconds);
+
+                        if (_progressHistory.Count == 0 || _progressHistory[^1].CharacterIndex != CurrentCharacterIndex)
+                                _progressHistory.Add((CurrentAudioPosition, CurrentCharacterIndex));
+                }
+
+                private void OnSpeechCompleted(object? sender, SpeakCompletedEventArgs e)
+                {
+                        if (_currentPrompt != null && !ReferenceEquals(e.Prompt, _currentPrompt))
+                                return;
+
+                        _currentPrompt = null;
+
+                        if (_isStoppingForPause)
+                        {
+                                _isStoppingForPause = false;
+                                IsPlaying = false;
+                                IsPaused = true;
+                                return;
+                        }
+
+                        if (_isStoppingForSeek)
+                        {
+                                _isStoppingForSeek = false;
+                                if (_pendingSeekCharacterIndex.HasValue)
+                                {
+                                        CurrentCharacterIndex = _pendingSeekCharacterIndex.Value;
+                                        CurrentAudioPosition = _pendingSeekAudioPosition;
+                                        _pendingSeekCharacterIndex = null;
+                                        StartPlaybackFromCurrentPosition();
+                                }
+                                return;
+                        }
+
+                        if (e.Cancelled)
+                        {
+                                IsPlaying = false;
+                                return;
+                        }
+
+                        IsPlaying = false;
+                        IsPaused = false;
+
+                        if (PlainText != null)
+                        {
+                                CurrentCharacterIndex = PlainText.Length;
+                                CurrentAudioPosition = EstimateTimeFromCharacterIndex(CurrentCharacterIndex);
+                        }
                 }
         }
 }

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -182,13 +182,40 @@
                             Margin="24,0,0,0"
                             Style="{StaticResource CardContainerStyle}">
                         <Grid>
+                            <Grid.Resources>
+                                <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+                            </Grid.Resources>
                             <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <TextBlock Text="Document preview"
                                        Style="{StaticResource CardTitleTextStyle}"/>
-                            <FlowDocumentScrollViewer Grid.Row="1"
+                            <StackPanel Grid.Row="1"
+                                        Orientation="Horizontal"
+                                        Margin="0,12,0,0"
+                                        HorizontalAlignment="Left"
+                                        Visibility="{Binding IsDocumentLoaded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Button Content="⏪ 10s"
+                                        Command="{Binding SeekBackwardCommand}"
+                                        Style="{StaticResource PrimaryButtonStyle}"
+                                        MinWidth="80"
+                                        AutomationProperties.Name="Rewind 10 seconds"/>
+                                <Button Content="{Binding PlayPauseLabel}"
+                                        Command="{Binding PlayPauseCommand}"
+                                        Style="{StaticResource PrimaryButtonStyle}"
+                                        MinWidth="100"
+                                        Margin="12,0,0,0"
+                                        AutomationProperties.Name="Play or pause document narration"/>
+                                <Button Content="10s ⏩"
+                                        Command="{Binding SeekForwardCommand}"
+                                        Style="{StaticResource PrimaryButtonStyle}"
+                                        MinWidth="80"
+                                        Margin="12,0,0,0"
+                                        AutomationProperties.Name="Fast forward 10 seconds"/>
+                            </StackPanel>
+                            <FlowDocumentScrollViewer Grid.Row="2"
                                                       Margin="0,12,0,0"
                                                       Document="{Binding Document}"
                                                       VerticalScrollBarVisibility="Auto">
@@ -203,7 +230,7 @@
                                     </Style>
                                 </FlowDocumentScrollViewer.Style>
                             </FlowDocumentScrollViewer>
-                            <TextBlock Grid.Row="1"
+                            <TextBlock Grid.Row="2"
                                        Margin="0,20,0,0"
                                        Text="Open a document to preview its contents here."
                                        HorizontalAlignment="Center"


### PR DESCRIPTION
## Summary
- track text-to-speech playback state within `DocumentReaderViewModel` and expose play/pause plus seek commands
- surface new transport controls in the document reader UI and wire them to the updated view model
- extend the TTS service interface and unit test scaffolding to support speech progress notifications

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e136724730832d87699246115cf3e6