### PR TITLE
Keep document reader controls visible

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -195,24 +195,29 @@
                             <StackPanel Grid.Row="1"
                                         Orientation="Horizontal"
                                         Margin="0,12,0,0"
-                                        HorizontalAlignment="Left"
-                                        Visibility="{Binding IsDocumentLoaded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        HorizontalAlignment="Left">
                                 <Button Content="⏪ 10s"
                                         Command="{Binding SeekBackwardCommand}"
                                         Style="{StaticResource PrimaryButtonStyle}"
-                                        MinWidth="80"
+                                        MinWidth="120"
+                                        MinHeight="36"
+                                        IsEnabled="{Binding IsDocumentLoaded}"
                                         AutomationProperties.Name="Rewind 10 seconds"/>
                                 <Button Content="{Binding PlayPauseLabel}"
                                         Command="{Binding PlayPauseCommand}"
                                         Style="{StaticResource PrimaryButtonStyle}"
-                                        MinWidth="100"
+                                        MinWidth="140"
+                                        MinHeight="36"
                                         Margin="12,0,0,0"
+                                        IsEnabled="{Binding IsDocumentLoaded}"
                                         AutomationProperties.Name="Play or pause document narration"/>
                                 <Button Content="10s ⏩"
                                         Command="{Binding SeekForwardCommand}"
                                         Style="{StaticResource PrimaryButtonStyle}"
-                                        MinWidth="80"
+                                        MinWidth="120"
+                                        MinHeight="36"
                                         Margin="12,0,0,0"
+                                        IsEnabled="{Binding IsDocumentLoaded}"
                                         AutomationProperties.Name="Fast forward 10 seconds"/>
                             </StackPanel>
                             <FlowDocumentScrollViewer Grid.Row="2"


### PR DESCRIPTION
## Summary
- keep the document reader playback controls visible at all times
- adopt the shared primary button sizing so the reader controls match the rest of the UI

## Testing
- dotnet build Dissonance/Dissonance.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1396c28f4832d9102bc5ecc81b398