### PR TITLE
Add configurable document playback hotkey

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -3,9 +3,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Documents;
+using System.Windows.Input;
 using System.Speech.Synthesis;
 
+using Dissonance;
 using Dissonance.Services.DocumentReader;
+using Dissonance.Services.SettingsService;
 using Dissonance.Services.TTSService;
 using Dissonance.ViewModels;
 
@@ -20,7 +23,9 @@ namespace Dissonance.Tests.ViewModels
                 {
                         var result = new DocumentReadResult("sample.txt", "Hello world");
                         var service = new StubDocumentReaderService(result);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService());
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
 
                         var success = await viewModel.LoadDocumentAsync(result.FilePath);
 
@@ -46,7 +51,9 @@ namespace Dissonance.Tests.ViewModels
                 public async Task LoadDocumentAsync_WhenServiceThrows_ReturnsFalseAndSetsError()
                 {
                         var service = new FailingDocumentReaderService(new InvalidOperationException("boom"));
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService());
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
 
                         var success = await viewModel.LoadDocumentAsync("missing.txt");
 
@@ -66,7 +73,9 @@ namespace Dissonance.Tests.ViewModels
                 {
                         var result = new DocumentReadResult("sample.txt", "Hello world");
                         var service = new StubDocumentReaderService(result);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService());
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
 
                         viewModel.ClearDocumentCommand.Execute(null);
 
@@ -83,7 +92,9 @@ namespace Dissonance.Tests.ViewModels
                 {
                         var tcs = new TaskCompletionSource<DocumentReadResult>();
                         var service = new PendingDocumentReaderService(tcs);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService());
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
 
                         var loadTask = viewModel.LoadDocumentAsync("sample.txt");
 
@@ -94,6 +105,139 @@ namespace Dissonance.Tests.ViewModels
                         await loadTask;
 
                         Assert.True(viewModel.BrowseForDocumentCommand.CanExecute(null));
+                }
+
+                [Fact]
+                public void ApplyPlaybackHotkeyCommand_SavesSettingsAndUpdatesState()
+                {
+                        var result = new DocumentReadResult("sample.txt", "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var settings = CreateSettings();
+                        settings.DocumentReaderHotkey.Key = string.Empty;
+                        var settingsService = new StubSettingsService(settings);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+
+                        viewModel.PlaybackHotkeyCombination = "MediaPlayPause";
+
+                        Assert.True(viewModel.ApplyPlaybackHotkeyCommand.CanExecute(null));
+
+                        viewModel.ApplyPlaybackHotkeyCommand.Execute(null);
+
+                        Assert.Equal("MediaPlayPause", viewModel.PlaybackHotkeyCombination);
+                        Assert.Equal(Key.MediaPlayPause, viewModel.PlaybackHotkeyKey);
+                        Assert.Equal(ModifierKeys.None, viewModel.PlaybackHotkeyModifiers);
+                        Assert.Equal("MediaPlayPause", settings.DocumentReaderHotkey.Key);
+                        Assert.Equal(string.Empty, settings.DocumentReaderHotkey.Modifiers);
+                        Assert.Equal(1, settingsService.SaveCalls);
+                }
+
+                [Fact]
+                public async Task PlaybackHotkeyCommand_StopsPlaybackWhenToggleDisabled()
+                {
+                        var result = new DocumentReadResult("sample.txt", "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var ttsService = new StubTtsService(returnPrompt: true);
+                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService);
+
+                        await viewModel.LoadDocumentAsync(result.FilePath);
+
+                        viewModel.PlaybackHotkeyCombination = "MediaPlayPause";
+                        viewModel.ApplyPlaybackHotkeyCommand.Execute(null);
+
+                        viewModel.PlaybackHotkeyCommand.Execute(null);
+                        Assert.True(viewModel.IsPlaying);
+
+                        viewModel.PlaybackHotkeyCommand.Execute(null);
+
+                        Assert.False(viewModel.IsPlaying);
+                        Assert.False(viewModel.IsPaused);
+                        Assert.Equal(1, ttsService.StopCalls);
+                        Assert.Equal(1, settingsService.SaveCalls);
+                        Assert.Equal(0, viewModel.CurrentCharacterIndex);
+                }
+
+                [Fact]
+                public async Task PlaybackHotkeyCommand_TogglesPauseWhenEnabled()
+                {
+                        var result = new DocumentReadResult("sample.txt", "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var ttsService = new StubTtsService(returnPrompt: true);
+                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService);
+
+                        await viewModel.LoadDocumentAsync(result.FilePath);
+
+                        viewModel.PlaybackHotkeyTogglesPause = true;
+
+                        viewModel.PlaybackHotkeyCommand.Execute(null);
+                        Assert.True(viewModel.IsPlaying);
+
+                        viewModel.PlaybackHotkeyCommand.Execute(null);
+                        Assert.False(viewModel.IsPlaying);
+                        Assert.True(viewModel.IsPaused);
+
+                        viewModel.PlaybackHotkeyCommand.Execute(null);
+                        Assert.True(viewModel.IsPlaying);
+                        Assert.True(settings.DocumentReaderHotkey.UsePlayPauseToggle);
+                        Assert.Equal(1, settingsService.SaveCalls);
+                        Assert.True(ttsService.StopCalls >= 1);
+                }
+
+                private static AppSettings CreateSettings()
+                {
+                        return new AppSettings
+                        {
+                                Hotkey = new AppSettings.HotkeySettings(),
+                                DocumentReaderHotkey = new AppSettings.DocumentReaderHotkeySettings
+                                {
+                                        Key = "MediaPlayPause",
+                                        Modifiers = string.Empty,
+                                        UsePlayPauseToggle = false,
+                                }
+                        };
+                }
+
+                private sealed class StubSettingsService : ISettingsService
+                {
+                        private AppSettings _settings;
+
+                        public StubSettingsService(AppSettings settings)
+                        {
+                                _settings = settings;
+                        }
+
+                        public int SaveCalls { get; private set; }
+
+                        public AppSettings GetCurrentSettings() => _settings;
+
+                        public AppSettings LoadSettings() => _settings;
+
+                        public void ResetToFactorySettings()
+                        {
+                        }
+
+                        public void SaveSettings(AppSettings settings)
+                        {
+                                _settings = settings;
+                        }
+
+                        public bool SaveCurrentSettings()
+                        {
+                                SaveCalls++;
+                                return true;
+                        }
+
+                        public bool SaveCurrentSettingsAsDefault()
+                        {
+                                return true;
+                        }
+
+                        public bool ExportSettings(string destinationPath) => true;
+
+                        public bool ImportSettings(string sourcePath) => true;
                 }
 
                 private sealed class StubDocumentReaderService : IDocumentReaderService
@@ -143,6 +287,13 @@ namespace Dissonance.Tests.ViewModels
 
                 private sealed class StubTtsService : ITTSService
                 {
+                        private readonly bool _returnPrompt;
+
+                        public StubTtsService(bool returnPrompt = false)
+                        {
+                                _returnPrompt = returnPrompt;
+                        }
+
                         public event EventHandler<SpeakCompletedEventArgs>? SpeechCompleted
                         {
                                 add { }
@@ -155,14 +306,26 @@ namespace Dissonance.Tests.ViewModels
                                 remove { }
                         }
 
+                        public int StopCalls { get; private set; }
+
+                        public Prompt? LastPrompt { get; private set; }
+
                         public void SetTTSParameters(string voice, double rate, int volume)
                         {
                         }
 
-                        public Prompt? Speak(string text) => null;
+                        public Prompt? Speak(string text)
+                        {
+                                if (!_returnPrompt)
+                                        return null;
+
+                                LastPrompt = new Prompt(text);
+                                return LastPrompt;
+                        }
 
                         public void Stop()
                         {
+                                StopCalls++;
                         }
                 }
         }

--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -198,6 +198,12 @@ namespace Dissonance.Tests.ViewModels
                                 {
                                         Modifiers = "Alt",
                                         Key = "E"
+                                },
+                                DocumentReaderHotkey = new AppSettings.DocumentReaderHotkeySettings
+                                {
+                                        Key = "MediaPlayPause",
+                                        Modifiers = string.Empty,
+                                        UsePlayPauseToggle = false,
                                 }
                         };
 
@@ -209,7 +215,7 @@ namespace Dissonance.Tests.ViewModels
                         var clipboardService = new TestClipboardService();
                         var statusService = new TestStatusAnnouncementService();
                         var documentReaderService = new TestDocumentReaderService();
-                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService, ttsService);
+                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService, ttsService, settingsService);
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>(), statusService);
 
                         var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, statusService, documentReaderViewModel);
@@ -316,6 +322,12 @@ namespace Dissonance.Tests.ViewModels
                                         {
                                                 Modifiers = settings.Hotkey?.Modifiers ?? string.Empty,
                                                 Key = settings.Hotkey?.Key ?? string.Empty
+                                        },
+                                        DocumentReaderHotkey = new AppSettings.DocumentReaderHotkeySettings
+                                        {
+                                                Modifiers = settings.DocumentReaderHotkey?.Modifiers ?? string.Empty,
+                                                Key = settings.DocumentReaderHotkey?.Key ?? string.Empty,
+                                                UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? false,
                                         }
                                 };
                         }

--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -4,6 +4,8 @@ namespace Dissonance
         {
                 public HotkeySettings Hotkey { get; set; }
 
+                public DocumentReaderHotkeySettings DocumentReaderHotkey { get; set; }
+
                 public string Voice { get; set; }
 
                 public double VoiceRate { get; set; }
@@ -31,6 +33,15 @@ namespace Dissonance
                         public string Modifiers { get; set; }
 
                         public bool AutoReadClipboard { get; set; }
+                }
+
+                public class DocumentReaderHotkeySettings
+                {
+                        public string Key { get; set; }
+
+                        public string Modifiers { get; set; }
+
+                        public bool UsePlayPauseToggle { get; set; }
                 }
         }
 }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -177,6 +177,7 @@ namespace Dissonance.Services.SettingsService
                                 WindowHeight = null,
                                 IsWindowMaximized = false,
                                 Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
+                                DocumentReaderHotkey = new DocumentReaderHotkeySettings { Modifiers = string.Empty, Key = "MediaPlayPause", UsePlayPauseToggle = false },
                         };
                 }
 
@@ -199,6 +200,12 @@ namespace Dissonance.Services.SettingsService
                                         Modifiers = settings.Hotkey?.Modifiers ?? string.Empty,
                                         Key = settings.Hotkey?.Key ?? string.Empty,
                                         AutoReadClipboard = settings.Hotkey?.AutoReadClipboard ?? false,
+                                },
+                                DocumentReaderHotkey = new DocumentReaderHotkeySettings
+                                {
+                                        Modifiers = settings.DocumentReaderHotkey?.Modifiers ?? string.Empty,
+                                        Key = settings.DocumentReaderHotkey?.Key ?? string.Empty,
+                                        UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? false,
                                 }
                         };
                 }
@@ -226,6 +233,12 @@ namespace Dissonance.Services.SettingsService
                                         Modifiers = string.IsNullOrWhiteSpace ( settings.Hotkey?.Modifiers ) ? reference.Hotkey.Modifiers : settings.Hotkey.Modifiers,
                                         Key = string.IsNullOrWhiteSpace ( settings.Hotkey?.Key ) ? reference.Hotkey.Key : settings.Hotkey.Key,
                                         AutoReadClipboard = settings.Hotkey?.AutoReadClipboard ?? reference.Hotkey.AutoReadClipboard,
+                                },
+                                DocumentReaderHotkey = new DocumentReaderHotkeySettings
+                                {
+                                        Modifiers = string.IsNullOrWhiteSpace ( settings.DocumentReaderHotkey?.Modifiers ) ? reference.DocumentReaderHotkey.Modifiers : settings.DocumentReaderHotkey.Modifiers,
+                                        Key = string.IsNullOrWhiteSpace ( settings.DocumentReaderHotkey?.Key ) ? reference.DocumentReaderHotkey.Key : settings.DocumentReaderHotkey.Key,
+                                        UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? reference.DocumentReaderHotkey.UsePlayPauseToggle,
                                 }
                         };
 

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -67,7 +67,7 @@ namespace Dissonance.ViewModels
                         _playPauseCommand = new RelayCommandNoParam(TogglePlayback, () => !IsBusy && CanReadDocument);
                         _seekBackwardCommand = new RelayCommandNoParam(() => SeekBy(TimeSpan.FromSeconds(-10)), () => !IsBusy && CanReadDocument);
                         _seekForwardCommand = new RelayCommandNoParam(() => SeekBy(TimeSpan.FromSeconds(10)), () => !IsBusy && CanReadDocument);
-                        _playbackHotkeyCommand = new RelayCommandNoParam(ExecutePlaybackHotkey, () => !IsBusy && CanReadDocument);
+                        _playbackHotkeyCommand = new RelayCommandNoParam(ExecutePlaybackHotkey, () => !IsBusy && (HasPlainText || IsPlaying || IsPaused));
                         _applyPlaybackHotkeyCommand = new RelayCommandNoParam(ApplyPlaybackHotkey, CanApplyPlaybackHotkey);
 
                         _ttsService.SpeechCompleted += OnSpeechCompleted;
@@ -109,6 +109,7 @@ namespace Dissonance.ViewModels
                                 OnPropertyChanged(nameof(WordCount));
                                 OnPropertyChanged(nameof(CharacterCount));
                                 OnPropertyChanged(nameof(CanReadDocument));
+                                UpdateCommandStates();
                         }
                 }
 
@@ -178,6 +179,7 @@ namespace Dissonance.ViewModels
                                 _isPlaying = value;
                                 OnPropertyChanged();
                                 OnPropertyChanged(nameof(PlayPauseLabel));
+                                _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         }
                 }
 
@@ -192,6 +194,7 @@ namespace Dissonance.ViewModels
                                 _isPaused = value;
                                 OnPropertyChanged();
                                 OnPropertyChanged(nameof(PlayPauseLabel));
+                                _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         }
                 }
 
@@ -474,12 +477,12 @@ namespace Dissonance.ViewModels
 
                 private void ExecutePlaybackHotkey()
                 {
-                        if (!CanReadDocument)
+                        if (!HasPlainText && !IsPlaying && !IsPaused)
                                 return;
 
                         if (PlaybackHotkeyTogglesPause)
                         {
-                                TogglePlayback();
+                                TogglePlaybackInternal();
                                 return;
                         }
 
@@ -659,6 +662,14 @@ namespace Dissonance.ViewModels
                 private void TogglePlayback()
                 {
                         if (!CanReadDocument)
+                                return;
+
+                        TogglePlaybackInternal();
+                }
+
+                private void TogglePlaybackInternal()
+                {
+                        if (!HasPlainText && !IsPlaying && !IsPaused)
                                 return;
 
                         if (!IsPlaying && !IsPaused)

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -193,11 +193,6 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <Grid.InputBindings>
-                                <KeyBinding Key="{Binding PlaybackHotkeyKey}"
-                                            Modifiers="{Binding PlaybackHotkeyModifiers}"
-                                            Command="{Binding PlaybackHotkeyCommand}"/>
-                            </Grid.InputBindings>
                             <TextBlock Text="Document preview"
                                        Style="{StaticResource CardTitleTextStyle}"/>
                             <StackPanel Grid.Row="1"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -190,8 +190,14 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
+                            <Grid.InputBindings>
+                                <KeyBinding Key="{Binding PlaybackHotkeyKey}"
+                                            Modifiers="{Binding PlaybackHotkeyModifiers}"
+                                            Command="{Binding PlaybackHotkeyCommand}"/>
+                            </Grid.InputBindings>
                             <TextBlock Text="Document preview"
                                        Style="{StaticResource CardTitleTextStyle}"/>
                             <StackPanel Grid.Row="1"
@@ -222,7 +228,44 @@
                                         IsEnabled="{Binding IsDocumentLoaded}"
                                         AutomationProperties.Name="Fast forward 10 seconds"/>
                             </StackPanel>
-                            <FlowDocumentScrollViewer Grid.Row="2"
+                            <StackPanel Grid.Row="2"
+                                        Margin="0,16,0,0">
+                                <TextBlock x:Name="PlaybackHotkeyHeading"
+                                           Text="Playback hotkey"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                <TextBlock Margin="0,4,0,0"
+                                           Text="Assign a shortcut to control document narration while reviewing the preview."
+                                           Style="{StaticResource CardDescriptionTextStyle}"
+                                           TextWrapping="Wrap"/>
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,8,0,0">
+                                    <TextBox x:Name="DocumentPlaybackHotkeyTextBox"
+                                             Width="180"
+                                             Style="{StaticResource ModernTextBoxStyle}"
+                                             Text="{Binding PlaybackHotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             IsReadOnly="True"
+                                             PreviewKeyDown="DocumentPlaybackHotkeyTextBox_PreviewKeyDown"
+                                             AutomationProperties.LabeledBy="{Binding ElementName=PlaybackHotkeyHeading}"
+                                             AutomationProperties.Name="Document playback hotkey"
+                                             AutomationProperties.HelpText="Set the hotkey used to play or stop document narration"/>
+                                    <Button Content="Apply"
+                                            Style="{StaticResource PrimaryButtonStyle}"
+                                            Command="{Binding ApplyPlaybackHotkeyCommand}"
+                                            Margin="12,0,0,0"
+                                            MinWidth="96"
+                                            AutomationProperties.Name="Apply document playback hotkey"
+                                            AutomationProperties.HelpText="Applies the document playback hotkey combination"/>
+                                </StackPanel>
+                                <CheckBox Margin="0,12,0,0"
+                                          Content="Use the hotkey to play and pause instead of stopping"
+                                          Style="{StaticResource MenuCheckBoxStyle}"
+                                          IsChecked="{Binding PlaybackHotkeyTogglesPause, Mode=TwoWay}"
+                                          ToolTip="When enabled, pressing the hotkey toggles between play and pause."
+                                          AutomationProperties.Name="Toggle playback hotkey pause behavior"
+                                          AutomationProperties.HelpText="Enable to make the playback hotkey pause and resume the document preview"/>
+                            </StackPanel>
+                            <FlowDocumentScrollViewer Grid.Row="3"
                                                       Margin="0,12,0,0"
                                                       Document="{Binding Document}"
                                                       VerticalScrollBarVisibility="Auto">
@@ -237,7 +280,7 @@
                                     </Style>
                                 </FlowDocumentScrollViewer.Style>
                             </FlowDocumentScrollViewer>
-                            <TextBlock Grid.Row="2"
+                            <TextBlock Grid.Row="3"
                                        Margin="0,20,0,0"
                                        Text="Open a document to preview its contents here."
                                        HorizontalAlignment="Center"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -333,6 +333,53 @@ namespace Dissonance
                         _viewModel.HotkeyCombination = string.Join ( "+", hotkeyParts );
                 }
 
+                private void DocumentPlaybackHotkeyTextBox_PreviewKeyDown ( object sender, KeyEventArgs e )
+                {
+                        if ( sender is not TextBox textBox )
+                                return;
+
+                        if ( textBox.DataContext is not DocumentReaderViewModel documentReaderViewModel )
+                                return;
+
+                        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+
+                        if ( key == Key.Tab )
+                        {
+                                var modifiersState = Keyboard.Modifiers;
+                                if ( modifiersState == ModifierKeys.None || modifiersState == ModifierKeys.Shift )
+                                {
+                                        e.Handled = false;
+                                        return;
+                                }
+                        }
+
+                        if ( key == Key.Back || key == Key.Delete || key == Key.Escape )
+                        {
+                                e.Handled = true;
+                                documentReaderViewModel.PlaybackHotkeyCombination = string.Empty;
+                                return;
+                        }
+
+                        e.Handled = true;
+
+                        if ( key == Key.None )
+                        {
+                                documentReaderViewModel.PlaybackHotkeyCombination = string.Empty;
+                                return;
+                        }
+
+                        var modifiers = GetActiveModifiers ( );
+
+                        if ( IsModifierKey ( key ) )
+                        {
+                                documentReaderViewModel.PlaybackHotkeyCombination = string.Join ( "+", modifiers );
+                                return;
+                        }
+
+                        modifiers.Add ( key.ToString ( ) );
+                        documentReaderViewModel.PlaybackHotkeyCombination = string.Join ( "+", modifiers );
+                }
+
                 private static bool IsModifierKey ( Key key )
                 {
                         return ModifierKeySet.Contains ( key );


### PR DESCRIPTION
## Summary
- add a document playback hotkey with an optional play/pause toggle stored in settings
- update the document reader UI to capture media keys and configure the new shortcut
- extend unit tests to cover the new hotkey behaviors and settings persistence

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e13bc7f44c832db53a39f602002a22