### PR TITLE
Handle media keys for document playback

### DIFF
--- a/Dissonance/Dissonance/Services/DocumentReader/IDocumentReaderService.cs
+++ b/Dissonance/Dissonance/Services/DocumentReader/IDocumentReaderService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 
 namespace Dissonance.Services.DocumentReader
 {
@@ -13,14 +14,22 @@ namespace Dissonance.Services.DocumentReader
         public sealed class DocumentReadResult
         {
                 public DocumentReadResult(string filePath, string plainText)
+                        : this(filePath, null, plainText)
+                {
+                }
+
+                public DocumentReadResult(string filePath, FlowDocument? document, string plainText)
                 {
                         FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+                        Document = document;
                         PlainText = plainText ?? string.Empty;
                 }
 
                 public string FilePath { get; }
 
                 public string FileName => Path.GetFileName(FilePath);
+
+                public FlowDocument? Document { get; }
 
                 public string PlainText { get; }
 

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -371,7 +371,7 @@ namespace Dissonance.ViewModels
                         if (result == null)
                                 throw new ArgumentNullException(nameof(result));
 
-                        Document = CreateFlowDocument(result.PlainText);
+                        Document = result.Document ?? CreateFlowDocument(result.PlainText);
                         PlainText = result.PlainText;
                         FilePath = result.FilePath;
                         LastError = null;

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -32,11 +32,11 @@ namespace Dissonance
                         { 12, Key.MediaPreviousTrack },
                         { 13, Key.MediaStop },
                         { 14, Key.MediaPlayPause },
-                        { 46, Key.MediaPlay },
-                        { 47, Key.MediaPause },
-                        { 48, Key.MediaRecord },
-                        { 49, Key.MediaFastForward },
-                        { 50, Key.MediaRewind },
+                        { 46, Key.Play },
+                        { 47, Key.Pause },
+                        { 48, Key.Record },
+                        { 49, Key.FastForward },
+                        { 50, Key.Rewind },
                 };
                 private static readonly HashSet<Key> ModifierKeySet = new HashSet<Key>
                 {

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -34,9 +34,6 @@ namespace Dissonance
                         { 14, Key.MediaPlayPause },
                         { 46, Key.Play },
                         { 47, Key.Pause },
-                        { 48, Key.Record },
-                        { 49, Key.FastForward },
-                        { 50, Key.Rewind },
                 };
                 private static readonly HashSet<Key> ModifierKeySet = new HashSet<Key>
                 {

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -23,17 +23,11 @@ namespace Dissonance
                 private WindowState _lastNonMinimizedWindowState = WindowState.Normal;
                 private bool _isWindowPlacementDirty;
                 private KeyBinding? _documentPlaybackKeyBinding;
-                private static readonly Dictionary<int, Key> AppCommandToKeyMap = new()
+                private static readonly HashSet<int> PlaybackAppCommands = new()
                 {
-                        { 8, Key.VolumeMute },
-                        { 9, Key.VolumeDown },
-                        { 10, Key.VolumeUp },
-                        { 11, Key.MediaNextTrack },
-                        { 12, Key.MediaPreviousTrack },
-                        { 13, Key.MediaStop },
-                        { 14, Key.MediaPlayPause },
-                        { 46, Key.Play },
-                        { 47, Key.Pause },
+                        14, // APPCOMMAND_MEDIA_PLAY_PAUSE
+                        46, // APPCOMMAND_MEDIA_PLAY
+                        47, // APPCOMMAND_MEDIA_PAUSE
                 };
                 private static readonly HashSet<Key> ModifierKeySet = new HashSet<Key>
                 {
@@ -530,13 +524,7 @@ namespace Dissonance
                 private bool TryHandleAppCommand ( IntPtr lParam )
                 {
                         var command = GetAppCommand ( lParam );
-                        if ( !AppCommandToKeyMap.TryGetValue ( command, out var key ) )
-                        {
-                                return false;
-                        }
-
-                        if ( _documentReaderViewModel.PlaybackHotkeyKey != key
-                                || _documentReaderViewModel.PlaybackHotkeyModifiers != ModifierKeys.None )
+                        if ( !PlaybackAppCommands.Contains ( command ) )
                         {
                                 return false;
                         }

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -18,10 +18,26 @@ namespace Dissonance
         {
                 private readonly MainWindowViewModel _viewModel;
                 private readonly ISettingsService _settingsService;
+                private readonly DocumentReaderViewModel _documentReaderViewModel;
                 private bool _isWindowPlacementInitialized;
                 private WindowState _lastNonMinimizedWindowState = WindowState.Normal;
                 private bool _isWindowPlacementDirty;
                 private KeyBinding? _documentPlaybackKeyBinding;
+                private static readonly Dictionary<int, Key> AppCommandToKeyMap = new()
+                {
+                        { 8, Key.VolumeMute },
+                        { 9, Key.VolumeDown },
+                        { 10, Key.VolumeUp },
+                        { 11, Key.MediaNextTrack },
+                        { 12, Key.MediaPreviousTrack },
+                        { 13, Key.MediaStop },
+                        { 14, Key.MediaPlayPause },
+                        { 46, Key.MediaPlay },
+                        { 47, Key.MediaPause },
+                        { 48, Key.MediaRecord },
+                        { 49, Key.MediaFastForward },
+                        { 50, Key.MediaRewind },
+                };
                 private static readonly HashSet<Key> ModifierKeySet = new HashSet<Key>
                 {
                         Key.LeftCtrl,
@@ -41,9 +57,9 @@ namespace Dissonance
                         InitializeComponent ( );
                         DataContext = _viewModel;
 
-                        var documentReaderViewModel = _viewModel.DocumentReader;
-                        documentReaderViewModel.PropertyChanged += OnDocumentReaderPropertyChanged;
-                        UpdateDocumentPlaybackHotkeyBinding ( documentReaderViewModel );
+                        _documentReaderViewModel = _viewModel.DocumentReader;
+                        _documentReaderViewModel.PropertyChanged += OnDocumentReaderPropertyChanged;
+                        UpdateDocumentPlaybackHotkeyBinding ( _documentReaderViewModel );
 
                         SourceInitialized += OnSourceInitialized;
                         LocationChanged += OnWindowLocationChanged;
@@ -53,8 +69,7 @@ namespace Dissonance
 
                 protected override void OnClosing ( CancelEventArgs e )
                 {
-                        var documentReaderViewModel = _viewModel.DocumentReader;
-                        documentReaderViewModel.PropertyChanged -= OnDocumentReaderPropertyChanged;
+                        _documentReaderViewModel.PropertyChanged -= OnDocumentReaderPropertyChanged;
 
                         PersistWindowPlacement ( );
                         if ( _isWindowPlacementDirty )
@@ -81,6 +96,13 @@ namespace Dissonance
                         {
                                 WmGetMinMaxInfo ( hwnd, lParam );
                                 handled = true;
+                        }
+                        else if ( msg == WM_APPCOMMAND )
+                        {
+                                if ( TryHandleAppCommand ( lParam ) )
+                                {
+                                        handled = true;
+                                }
                         }
 
                         return IntPtr.Zero;
@@ -508,7 +530,37 @@ namespace Dissonance
                         e.Handled = true;
                 }
 
+                private bool TryHandleAppCommand ( IntPtr lParam )
+                {
+                        var command = GetAppCommand ( lParam );
+                        if ( !AppCommandToKeyMap.TryGetValue ( command, out var key ) )
+                        {
+                                return false;
+                        }
+
+                        if ( _documentReaderViewModel.PlaybackHotkeyKey != key
+                                || _documentReaderViewModel.PlaybackHotkeyModifiers != ModifierKeys.None )
+                        {
+                                return false;
+                        }
+
+                        var playbackCommand = _documentReaderViewModel.PlaybackHotkeyCommand;
+                        if ( !playbackCommand.CanExecute ( null ) )
+                        {
+                                return false;
+                        }
+
+                        playbackCommand.Execute ( null );
+                        return true;
+                }
+
+                private static int GetAppCommand ( IntPtr lParam )
+                {
+                        return ( ( int ) ( ( long ) lParam >> 16 ) ) & 0x0FFF;
+                }
+
                 private const int WM_GETMINMAXINFO = 0x0024;
+                private const int WM_APPCOMMAND = 0x0319;
                 private const int MONITOR_DEFAULTTONEAREST = 0x00000002;
 
                 [DllImport ( "user32.dll" )]


### PR DESCRIPTION
## Summary
- map WM_APPCOMMAND messages to media keys and trigger the document playback command
- reuse the document reader view model instance when wiring up hotkey bindings

## Testing
- Not run (dotnet not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e14ad0d734832d8f2245eb0cc35cd7