### PR TITLE
Add configurable highlighting to document reader playback

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Speech.Synthesis;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Documents;
-
 using Dissonance;
 using Dissonance.Managers;
 using Dissonance.Services.ClipboardService;
@@ -229,8 +227,7 @@ namespace Dissonance.Tests.ViewModels
                 {
                         public Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
                         {
-                                var document = new FlowDocument(new Paragraph(new Run("Sample")));
-                                return Task.FromResult(new DocumentReadResult(filePath, document, "Sample"));
+                                return Task.FromResult(new DocumentReadResult(filePath, "Sample"));
                         }
                 }
 

--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -6,6 +6,8 @@ namespace Dissonance
 
                 public DocumentReaderHotkeySettings DocumentReaderHotkey { get; set; }
 
+                public string? DocumentReaderHighlightColor { get; set; }
+
                 public string Voice { get; set; }
 
                 public double VoiceRate { get; set; }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -178,6 +178,7 @@ namespace Dissonance.Services.SettingsService
                                 IsWindowMaximized = false,
                                 Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
                                 DocumentReaderHotkey = new DocumentReaderHotkeySettings { Modifiers = string.Empty, Key = "MediaPlayPause", UsePlayPauseToggle = false },
+                                DocumentReaderHighlightColor = "ThemeAccent",
                         };
                 }
 
@@ -206,7 +207,8 @@ namespace Dissonance.Services.SettingsService
                                         Modifiers = settings.DocumentReaderHotkey?.Modifiers ?? string.Empty,
                                         Key = settings.DocumentReaderHotkey?.Key ?? string.Empty,
                                         UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? false,
-                                }
+                                },
+                                DocumentReaderHighlightColor = settings.DocumentReaderHighlightColor
                         };
                 }
 
@@ -239,7 +241,8 @@ namespace Dissonance.Services.SettingsService
                                         Modifiers = string.IsNullOrWhiteSpace ( settings.DocumentReaderHotkey?.Modifiers ) ? reference.DocumentReaderHotkey.Modifiers : settings.DocumentReaderHotkey.Modifiers,
                                         Key = string.IsNullOrWhiteSpace ( settings.DocumentReaderHotkey?.Key ) ? reference.DocumentReaderHotkey.Key : settings.DocumentReaderHotkey.Key,
                                         UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? reference.DocumentReaderHotkey.UsePlayPauseToggle,
-                                }
+                                },
+                                DocumentReaderHighlightColor = string.IsNullOrWhiteSpace ( settings.DocumentReaderHighlightColor ) ? reference.DocumentReaderHighlightColor : settings.DocumentReaderHighlightColor,
                         };
 
                         return normalized;

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -705,11 +705,6 @@ namespace Dissonance.ViewModels
                         }
                 }
 
-                private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-                {
-                        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-                }
-
                 private static FlowDocument CreateFlowDocument(string content)
                 {
                         var document = new FlowDocument();

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -99,10 +99,10 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _document = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(IsDocumentLoaded));
-                                OnPropertyChanged(nameof(CanReadDocument));
-                                OnPropertyChanged(nameof(FileName));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(IsDocumentLoaded));
+                                RaisePropertyChanged(nameof(CanReadDocument));
+                                RaisePropertyChanged(nameof(FileName));
                                 UpdateCommandStates();
                         }
                 }
@@ -116,11 +116,11 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _plainText = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(HasPlainText));
-                                OnPropertyChanged(nameof(WordCount));
-                                OnPropertyChanged(nameof(CharacterCount));
-                                OnPropertyChanged(nameof(CanReadDocument));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(HasPlainText));
+                                RaisePropertyChanged(nameof(WordCount));
+                                RaisePropertyChanged(nameof(CharacterCount));
+                                RaisePropertyChanged(nameof(CanReadDocument));
                                 UpdateCommandStates();
                         }
                 }
@@ -134,8 +134,8 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _filePath = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(FileName));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(FileName));
                         }
                 }
 
@@ -157,7 +157,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _playbackHotkeyCombination = newValue;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                                 _applyPlaybackHotkeyCommand.RaiseCanExecuteChanged();
                         }
                 }
@@ -171,7 +171,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _playbackHotkeyTogglesPause = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                                 SavePlaybackHotkeySettings();
                         }
                 }
@@ -189,8 +189,8 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _isPlaying = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(PlayPauseLabel));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(PlayPauseLabel));
                                 _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         }
                 }
@@ -204,8 +204,8 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _isPaused = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(PlayPauseLabel));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(PlayPauseLabel));
                                 _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         }
                 }
@@ -219,7 +219,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _currentAudioPosition = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                         }
                 }
 
@@ -232,7 +232,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _currentCharacterIndex = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                         }
                 }
 
@@ -273,7 +273,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _highlightStartIndex = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                         }
                 }
 
@@ -286,7 +286,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _highlightLength = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                         }
                 }
 
@@ -299,7 +299,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _isBusy = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                                 UpdateCommandStates();
                         }
                 }
@@ -313,8 +313,8 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _statusMessage = value;
-                                OnPropertyChanged();
-                                OnPropertyChanged(nameof(HasStatusMessage));
+                                RaisePropertyChanged();
+                                RaisePropertyChanged(nameof(HasStatusMessage));
                                 UpdateCommandStates();
                         }
                 }
@@ -330,7 +330,7 @@ namespace Dissonance.ViewModels
                                         return;
 
                                 _lastError = value;
-                                OnPropertyChanged();
+                                RaisePropertyChanged();
                         }
                 }
 
@@ -469,10 +469,10 @@ namespace Dissonance.ViewModels
                         _playbackHotkeyModifiers = modifiers;
                         _playbackHotkeyKey = key;
 
-                        OnPropertyChanged(nameof(PlaybackHotkeyCombination));
-                        OnPropertyChanged(nameof(PlaybackHotkeyKey));
-                        OnPropertyChanged(nameof(PlaybackHotkeyModifiers));
-                        OnPropertyChanged(nameof(PlaybackHotkeyTogglesPause));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyCombination));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyKey));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyModifiers));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyTogglesPause));
                         _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         _applyPlaybackHotkeyCommand.RaiseCanExecuteChanged();
                 }
@@ -514,9 +514,9 @@ namespace Dissonance.ViewModels
                                 _playbackHotkeyCombination = string.Empty;
                                 _lastAppliedPlaybackHotkeyCombination = string.Empty;
 
-                                OnPropertyChanged(nameof(PlaybackHotkeyCombination));
-                                OnPropertyChanged(nameof(PlaybackHotkeyKey));
-                                OnPropertyChanged(nameof(PlaybackHotkeyModifiers));
+                                RaisePropertyChanged(nameof(PlaybackHotkeyCombination));
+                                RaisePropertyChanged(nameof(PlaybackHotkeyKey));
+                                RaisePropertyChanged(nameof(PlaybackHotkeyModifiers));
 
                                 SavePlaybackHotkeySettings();
                                 _applyPlaybackHotkeyCommand.RaiseCanExecuteChanged();
@@ -531,15 +531,15 @@ namespace Dissonance.ViewModels
                         if (_playbackHotkeyCombination != canonical)
                         {
                                 _playbackHotkeyCombination = canonical;
-                                OnPropertyChanged(nameof(PlaybackHotkeyCombination));
+                                RaisePropertyChanged(nameof(PlaybackHotkeyCombination));
                         }
 
                         _playbackHotkeyModifiers = modifiers;
                         _playbackHotkeyKey = key;
                         _lastAppliedPlaybackHotkeyCombination = canonical;
 
-                        OnPropertyChanged(nameof(PlaybackHotkeyKey));
-                        OnPropertyChanged(nameof(PlaybackHotkeyModifiers));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyKey));
+                        RaisePropertyChanged(nameof(PlaybackHotkeyModifiers));
 
                         SavePlaybackHotkeySettings();
                         _applyPlaybackHotkeyCommand.RaiseCanExecuteChanged();
@@ -981,7 +981,7 @@ namespace Dissonance.ViewModels
                         if (!ReferenceEquals(_selectedHighlightColor, newOption))
                         {
                                 _selectedHighlightColor = newOption;
-                                OnPropertyChanged(nameof(SelectedHighlightColor));
+                                RaisePropertyChanged(nameof(SelectedHighlightColor));
                         }
 
                         UpdateHighlightBrush();
@@ -1004,11 +1004,11 @@ namespace Dissonance.ViewModels
                         if (!ReferenceEquals(_highlightBrush, brush))
                         {
                                 _highlightBrush = brush;
-                                OnPropertyChanged(nameof(HighlightBrush));
+                                RaisePropertyChanged(nameof(HighlightBrush));
                         }
                         else
                         {
-                                OnPropertyChanged(nameof(HighlightBrush));
+                                RaisePropertyChanged(nameof(HighlightBrush));
                         }
                 }
 
@@ -1049,7 +1049,7 @@ namespace Dissonance.ViewModels
                         HighlightLength = clampedLength;
                 }
 
-                private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+                private void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
                 {
                         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
                 }

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -3,10 +3,14 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Speech.Synthesis;
 
 using Dissonance.Infrastructure.Commands;
@@ -54,8 +58,14 @@ namespace Dissonance.ViewModels
                 private Key _playbackHotkeyKey = Key.None;
                 private ModifierKeys _playbackHotkeyModifiers = ModifierKeys.None;
                 private bool _playbackHotkeyTogglesPause;
+                private readonly IReadOnlyList<HighlightColorOption> _highlightColorOptions;
+                private HighlightColorOption _selectedHighlightColor = null!;
+                private Brush _highlightBrush = Brushes.Transparent;
+                private int _highlightStartIndex;
+                private int _highlightLength;
 
                 private const double DefaultCharactersPerSecond = 15d;
+                private const string ThemeAccentHighlightId = "ThemeAccent";
 
                 public DocumentReaderViewModel(IDocumentReaderService documentReaderService, ITTSService ttsService, ISettingsService settingsService)
                 {
@@ -74,6 +84,8 @@ namespace Dissonance.ViewModels
                         _ttsService.SpeechProgress += OnSpeechProgress;
 
                         InitializePlaybackHotkeyFromSettings();
+                        _highlightColorOptions = CreateHighlightColorOptions();
+                        InitializeHighlightSettings();
                 }
 
                 public event PropertyChangedEventHandler? PropertyChanged;
@@ -229,6 +241,54 @@ namespace Dissonance.ViewModels
                 public int WordCount => _plainText?.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length ?? 0;
 
                 public int CharacterCount => _plainText?.Length ?? 0;
+
+                public IReadOnlyList<HighlightColorOption> HighlightColorOptions => _highlightColorOptions;
+
+                public HighlightColorOption SelectedHighlightColor
+                {
+                        get => _selectedHighlightColor;
+                        set
+                        {
+                                if (value == null)
+                                        value = _highlightColorOptions.First();
+
+                                if (ReferenceEquals(_selectedHighlightColor, value))
+                                {
+                                        UpdateHighlightBrush();
+                                        return;
+                                }
+
+                                SetSelectedHighlightColor(value, true);
+                        }
+                }
+
+                public Brush HighlightBrush => _highlightBrush;
+
+                public int HighlightStartIndex
+                {
+                        get => _highlightStartIndex;
+                        private set
+                        {
+                                if (_highlightStartIndex == value)
+                                        return;
+
+                                _highlightStartIndex = value;
+                                OnPropertyChanged();
+                        }
+                }
+
+                public int HighlightLength
+                {
+                        get => _highlightLength;
+                        private set
+                        {
+                                if (_highlightLength == value)
+                                        return;
+
+                                _highlightLength = value;
+                                OnPropertyChanged();
+                        }
+                }
 
                 public bool IsBusy
                 {
@@ -415,6 +475,16 @@ namespace Dissonance.ViewModels
                         OnPropertyChanged(nameof(PlaybackHotkeyTogglesPause));
                         _playbackHotkeyCommand.RaiseCanExecuteChanged();
                         _applyPlaybackHotkeyCommand.RaiseCanExecuteChanged();
+                }
+
+                private void InitializeHighlightSettings()
+                {
+                        var settings = _settingsService.GetCurrentSettings();
+                        var selectedId = settings.DocumentReaderHighlightColor;
+                        var option = _highlightColorOptions.FirstOrDefault(o => string.Equals(o.Id, selectedId, StringComparison.Ordinal))
+                                     ?? _highlightColorOptions.First();
+
+                        SetSelectedHighlightColor(option, false);
                 }
 
                 private bool CanApplyPlaybackHotkey()
@@ -643,19 +713,9 @@ namespace Dissonance.ViewModels
                 private static FlowDocument CreateFlowDocument(string content)
                 {
                         var document = new FlowDocument();
-                        if (string.IsNullOrEmpty(content))
-                        {
-                                document.Blocks.Add(new Paragraph(new Run(string.Empty)));
-                                return document;
-                        }
-
-                        var normalized = content.Replace("\r\n", "\n").Replace('\r', '\n');
-                        var lines = normalized.Split('\n');
-                        foreach (var line in lines)
-                        {
-                                document.Blocks.Add(new Paragraph(new Run(line)));
-                        }
-
+                        var paragraph = new Paragraph();
+                        paragraph.Inlines.Add(new Run(content ?? string.Empty));
+                        document.Blocks.Add(paragraph);
                         return document;
                 }
 
@@ -727,6 +787,7 @@ namespace Dissonance.ViewModels
                         var textToSpeak = PlainText.Substring(CurrentCharacterIndex);
                         _playbackStartCharacterIndex = CurrentCharacterIndex;
                         _playbackStartAudioPosition = EstimateTimeFromCharacterIndex(CurrentCharacterIndex);
+                        SetHighlightRange(CurrentCharacterIndex, 0);
                         _currentPrompt = _ttsService.Speak(textToSpeak);
                         _pendingSeekCharacterIndex = null;
                         _pendingSeekAudioPosition = TimeSpan.Zero;
@@ -767,6 +828,7 @@ namespace Dissonance.ViewModels
 
                         CurrentCharacterIndex = targetIndex;
                         CurrentAudioPosition = targetTime;
+                        SetHighlightRange(CurrentCharacterIndex, 0);
 
                         if (IsPlaying)
                         {
@@ -794,6 +856,7 @@ namespace Dissonance.ViewModels
                         _pendingSeekAudioPosition = TimeSpan.Zero;
                         CurrentCharacterIndex = 0;
                         CurrentAudioPosition = TimeSpan.Zero;
+                        SetHighlightRange(0, 0);
                         IsPlaying = false;
                         IsPaused = false;
                 }
@@ -842,6 +905,10 @@ namespace Dissonance.ViewModels
 
                         if (_progressHistory.Count == 0 || _progressHistory[^1].CharacterIndex != CurrentCharacterIndex)
                                 _progressHistory.Add((CurrentAudioPosition, CurrentCharacterIndex));
+
+                        var highlightStart = Math.Clamp(_playbackStartCharacterIndex + e.CharacterPosition, 0, PlainText.Length);
+                        var highlightLength = Math.Clamp(e.CharacterCount, 0, PlainText.Length - highlightStart);
+                        SetHighlightRange(highlightStart, highlightLength);
                 }
 
                 private void OnSpeechCompleted(object? sender, SpeakCompletedEventArgs e)
@@ -875,6 +942,7 @@ namespace Dissonance.ViewModels
                         if (e.Cancelled)
                         {
                                 IsPlaying = false;
+                                SetHighlightRange(CurrentCharacterIndex, 0);
                                 return;
                         }
 
@@ -885,7 +953,129 @@ namespace Dissonance.ViewModels
                         {
                                 CurrentCharacterIndex = PlainText.Length;
                                 CurrentAudioPosition = EstimateTimeFromCharacterIndex(CurrentCharacterIndex);
+                                SetHighlightRange(CurrentCharacterIndex, 0);
                         }
+                }
+
+                public void RefreshHighlightBrush()
+                {
+                        UpdateHighlightBrush();
+                }
+
+                public void ReloadHighlightSettings()
+                {
+                        InitializeHighlightSettings();
+                }
+
+                private IReadOnlyList<HighlightColorOption> CreateHighlightColorOptions()
+                {
+                        return new ReadOnlyCollection<HighlightColorOption>(new List<HighlightColorOption>
+                        {
+                                new HighlightColorOption(ThemeAccentHighlightId, "Theme accent", null, "AccentBrush"),
+                                new HighlightColorOption("Warm", "Warm orange", Color.FromRgb(0xFF, 0x9E, 0x57)),
+                                new HighlightColorOption("Cool", "Cool blue", Color.FromRgb(0x42, 0xA5, 0xF5)),
+                                new HighlightColorOption("Calm", "Calm green", Color.FromRgb(0x66, 0xBB, 0x6A)),
+                                new HighlightColorOption("Violet", "Vibrant violet", Color.FromRgb(0xAB, 0x47, 0xBC)),
+                        });
+                }
+
+                private void SetSelectedHighlightColor(HighlightColorOption option, bool persist)
+                {
+                        var newOption = option ?? _highlightColorOptions.First();
+
+                        if (!ReferenceEquals(_selectedHighlightColor, newOption))
+                        {
+                                _selectedHighlightColor = newOption;
+                                OnPropertyChanged(nameof(SelectedHighlightColor));
+                        }
+
+                        UpdateHighlightBrush();
+
+                        if (persist)
+                        {
+                                var settings = _settingsService.GetCurrentSettings();
+                                if (!string.Equals(settings.DocumentReaderHighlightColor, newOption.Id, StringComparison.Ordinal))
+                                {
+                                        settings.DocumentReaderHighlightColor = newOption.Id;
+                                        _settingsService.SaveCurrentSettings();
+                                }
+                        }
+                }
+
+                private void UpdateHighlightBrush()
+                {
+                        var brush = ResolveBrushForOption(_selectedHighlightColor);
+
+                        if (!ReferenceEquals(_highlightBrush, brush))
+                        {
+                                _highlightBrush = brush;
+                                OnPropertyChanged(nameof(HighlightBrush));
+                        }
+                        else
+                        {
+                                OnPropertyChanged(nameof(HighlightBrush));
+                        }
+                }
+
+                private static Brush ResolveBrushForOption(HighlightColorOption option)
+                {
+                        if (option != null && !string.IsNullOrWhiteSpace(option.ResourceKey))
+                        {
+                                if (Application.Current?.TryFindResource(option.ResourceKey) is Brush resourceBrush)
+                                        return resourceBrush;
+                        }
+
+                        if (option != null && option.Color.HasValue)
+                        {
+                                var solid = new SolidColorBrush(option.Color.Value);
+                                if (solid.CanFreeze)
+                                        solid.Freeze();
+                                return solid;
+                        }
+
+                        return Brushes.Transparent;
+                }
+
+                private void SetHighlightRange(int startIndex, int length)
+                {
+                        var totalLength = PlainText?.Length ?? 0;
+                        if (totalLength <= 0)
+                        {
+                                HighlightStartIndex = 0;
+                                HighlightLength = 0;
+                                return;
+                        }
+
+                        var clampedStart = Math.Clamp(startIndex, 0, totalLength);
+                        var available = totalLength - clampedStart;
+                        var clampedLength = Math.Clamp(length, 0, available);
+
+                        HighlightStartIndex = clampedStart;
+                        HighlightLength = clampedLength;
+                }
+
+                private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+                {
+                        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                }
+
+                public sealed class HighlightColorOption
+                {
+                        public HighlightColorOption(string id, string displayName, Color? color = null, string? resourceKey = null)
+                        {
+                                Id = id ?? throw new ArgumentNullException(nameof(id));
+                                DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+                                Color = color;
+                                ResourceKey = resourceKey;
+                        }
+
+                        public string Id { get; }
+
+                        public string DisplayName { get; }
+
+                        public Color? Color { get; }
+
+                        public string? ResourceKey { get; }
                 }
         }
 }

--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -253,6 +253,7 @@ namespace Dissonance.ViewModels
                                         settings.UseDarkTheme = value;
                                         _settingsService.SaveCurrentSettings ( );
                                 }
+                                _documentReaderViewModel.RefreshHighlightBrush ( );
                                 OnPropertyChanged ( nameof ( IsDarkTheme ) );
                                 OnPropertyChanged ( nameof ( CurrentThemeName ) );
                         }
@@ -501,6 +502,7 @@ namespace Dissonance.ViewModels
                         }
 
                         _themeService.ApplyTheme ( settings.UseDarkTheme ? AppTheme.Dark : AppTheme.Light );
+                        _documentReaderViewModel.ReloadHighlightSettings ( );
                         if ( _isDarkTheme != settings.UseDarkTheme )
                         {
                                 _isDarkTheme = settings.UseDarkTheme;
@@ -523,6 +525,7 @@ namespace Dissonance.ViewModels
 
                         _isDarkTheme = settings.UseDarkTheme;
                         _themeService.ApplyTheme ( _isDarkTheme ? AppTheme.Dark : AppTheme.Light );
+                        _documentReaderViewModel.RefreshHighlightBrush ( );
                         OnPropertyChanged ( nameof ( IsDarkTheme ) );
                         OnPropertyChanged ( nameof ( CurrentThemeName ) );
 

--- a/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
+++ b/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
@@ -41,9 +41,9 @@ namespace Dissonance.Windows.Controls
                         set => SetValue(HighlightBrushProperty, value);
                 }
 
-                protected override void OnDocumentChanged(FlowDocument oldDocument, FlowDocument newDocument)
+                protected override void OnDocumentChanged(DependencyPropertyChangedEventArgs e)
                 {
-                        base.OnDocumentChanged(oldDocument, newDocument);
+                        base.OnDocumentChanged(e);
                         ClearHighlight();
                         _appliedStartIndex = -1;
                         _appliedLength = 0;

--- a/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
+++ b/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
@@ -41,14 +41,18 @@ namespace Dissonance.Windows.Controls
                         set => SetValue(HighlightBrushProperty, value);
                 }
 
-                protected override void OnDocumentChanged(DependencyPropertyChangedEventArgs e)
+                protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
                 {
-                        base.OnDocumentChanged(e);
-                        ClearHighlight();
-                        _appliedStartIndex = -1;
-                        _appliedLength = 0;
-                        _appliedBrush = null;
-                        UpdateHighlight();
+                        base.OnPropertyChanged(e);
+
+                        if (e.Property == FlowDocumentScrollViewer.DocumentProperty)
+                        {
+                                ClearHighlight();
+                                _appliedStartIndex = -1;
+                                _appliedLength = 0;
+                                _appliedBrush = null;
+                                UpdateHighlight();
+                        }
                 }
 
                 private static void OnHighlightChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
+++ b/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace Dissonance.Windows.Controls
+{
+        public class HighlightingFlowDocumentScrollViewer : FlowDocumentScrollViewer
+        {
+                public static readonly DependencyProperty HighlightStartIndexProperty =
+                        DependencyProperty.Register(nameof(HighlightStartIndex), typeof(int), typeof(HighlightingFlowDocumentScrollViewer), new PropertyMetadata(0, OnHighlightChanged));
+
+                public static readonly DependencyProperty HighlightLengthProperty =
+                        DependencyProperty.Register(nameof(HighlightLength), typeof(int), typeof(HighlightingFlowDocumentScrollViewer), new PropertyMetadata(0, OnHighlightChanged));
+
+                public static readonly DependencyProperty HighlightBrushProperty =
+                        DependencyProperty.Register(nameof(HighlightBrush), typeof(Brush), typeof(HighlightingFlowDocumentScrollViewer), new PropertyMetadata(Brushes.Transparent, OnHighlightChanged));
+
+                private TextRange? _currentHighlight;
+                private int _appliedStartIndex = -1;
+                private int _appliedLength;
+                private Brush? _appliedBrush;
+
+                public int HighlightStartIndex
+                {
+                        get => (int)GetValue(HighlightStartIndexProperty);
+                        set => SetValue(HighlightStartIndexProperty, value);
+                }
+
+                public int HighlightLength
+                {
+                        get => (int)GetValue(HighlightLengthProperty);
+                        set => SetValue(HighlightLengthProperty, value);
+                }
+
+                public Brush HighlightBrush
+                {
+                        get => (Brush)GetValue(HighlightBrushProperty);
+                        set => SetValue(HighlightBrushProperty, value);
+                }
+
+                protected override void OnDocumentChanged(FlowDocument oldDocument, FlowDocument newDocument)
+                {
+                        base.OnDocumentChanged(oldDocument, newDocument);
+                        ClearHighlight();
+                        _appliedStartIndex = -1;
+                        _appliedLength = 0;
+                        _appliedBrush = null;
+                        UpdateHighlight();
+                }
+
+                private static void OnHighlightChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+                {
+                        if (d is HighlightingFlowDocumentScrollViewer viewer)
+                        {
+                                viewer.UpdateHighlight();
+                        }
+                }
+
+                private void UpdateHighlight()
+                {
+                        var document = Document;
+                        if (document == null)
+                        {
+                                ClearHighlight();
+                                _appliedStartIndex = -1;
+                                _appliedLength = 0;
+                                _appliedBrush = null;
+                                return;
+                        }
+
+                        var highlightLength = HighlightLength;
+                        if (highlightLength <= 0)
+                        {
+                                ClearHighlight();
+                                _appliedStartIndex = -1;
+                                _appliedLength = 0;
+                                _appliedBrush = HighlightBrush;
+                                return;
+                        }
+
+                        var brush = HighlightBrush ?? Brushes.Transparent;
+                        if (_appliedStartIndex == HighlightStartIndex && _appliedLength == highlightLength && Equals(_appliedBrush, brush))
+                                return;
+
+                        ClearHighlight();
+
+                        var startPointer = GetTextPointerAtOffset(document, HighlightStartIndex);
+                        var endPointer = GetTextPointerAtOffset(document, HighlightStartIndex + highlightLength);
+                        if (startPointer == null || endPointer == null)
+                                return;
+
+                        var range = new TextRange(startPointer, endPointer);
+                        range.ApplyPropertyValue(TextElement.BackgroundProperty, brush);
+                        _currentHighlight = range;
+                        _appliedStartIndex = HighlightStartIndex;
+                        _appliedLength = highlightLength;
+                        _appliedBrush = brush;
+
+                        Dispatcher.BeginInvoke(new Action(() =>
+                        {
+                                try
+                                {
+                                        range.Start.Paragraph?.BringIntoView();
+                                }
+                                catch
+                                {
+                                }
+                        }), DispatcherPriority.Background);
+                }
+
+                private void ClearHighlight()
+                {
+                        if (_currentHighlight != null)
+                        {
+                                try
+                                {
+                                        _currentHighlight.ApplyPropertyValue(TextElement.BackgroundProperty, Brushes.Transparent);
+                                }
+                                catch
+                                {
+                                }
+
+                                _currentHighlight = null;
+                        }
+                }
+
+                private static TextPointer? GetTextPointerAtOffset(FlowDocument document, int offset)
+                {
+                        if (document == null)
+                                return null;
+
+                        var navigator = document.ContentStart;
+                        var remaining = Math.Max(0, offset);
+
+                        while (navigator != null && navigator.CompareTo(document.ContentEnd) < 0)
+                        {
+                                if (navigator.GetPointerContext(LogicalDirection.Forward) == TextPointerContext.Text)
+                                {
+                                        var textRun = navigator.GetTextInRun(LogicalDirection.Forward);
+                                        if (textRun.Length == 0)
+                                        {
+                                                navigator = navigator.GetNextContextPosition(LogicalDirection.Forward);
+                                                continue;
+                                        }
+
+                                        if (remaining <= textRun.Length)
+                                        {
+                                                return navigator.GetPositionAtOffset(remaining, LogicalDirection.Forward);
+                                        }
+
+                                        remaining -= textRun.Length;
+                                        navigator = navigator.GetPositionAtOffset(textRun.Length, LogicalDirection.Forward);
+                                }
+                                else
+                                {
+                                        navigator = navigator.GetNextContextPosition(LogicalDirection.Forward);
+                                }
+                        }
+
+                        return document.ContentEnd;
+                }
+        }
+}

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:Dissonance.ViewModels"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
+        xmlns:controls="clr-namespace:Dissonance.Windows.Controls"
         xmlns:status="clr-namespace:Dissonance.Services.StatusAnnouncements"
         mc:Ignorable="d"
         Title="Dissonance"
@@ -259,13 +260,32 @@
                                           ToolTip="When enabled, pressing the hotkey toggles between play and pause."
                                           AutomationProperties.Name="Toggle playback hotkey pause behavior"
                                           AutomationProperties.HelpText="Enable to make the playback hotkey pause and resume the document preview"/>
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,16,0,0"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Text="Highlight color"
+                                               Margin="0,0,12,0"
+                                               VerticalAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                    <ComboBox ItemsSource="{Binding HighlightColorOptions}"
+                                              SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
+                                              DisplayMemberPath="DisplayName"
+                                              Width="200"
+                                              Style="{StaticResource ModernComboBoxStyle}"
+                                              AutomationProperties.Name="Document highlight color"
+                                              AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
+                                </StackPanel>
                             </StackPanel>
-                            <FlowDocumentScrollViewer Grid.Row="3"
-                                                      Margin="0,12,0,0"
-                                                      Document="{Binding Document}"
-                                                      VerticalScrollBarVisibility="Auto">
-                                <FlowDocumentScrollViewer.Style>
-                                    <Style TargetType="FlowDocumentScrollViewer">
+                            <controls:HighlightingFlowDocumentScrollViewer Grid.Row="3"
+                                                                              Margin="0,12,0,0"
+                                                                              Document="{Binding Document}"
+                                                                              HighlightStartIndex="{Binding HighlightStartIndex}"
+                                                                              HighlightLength="{Binding HighlightLength}"
+                                                                              HighlightBrush="{Binding HighlightBrush}"
+                                                                              VerticalScrollBarVisibility="Auto">
+                                <controls:HighlightingFlowDocumentScrollViewer.Style>
+                                    <Style TargetType="controls:HighlightingFlowDocumentScrollViewer">
                                         <Setter Property="Visibility" Value="Collapsed"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsDocumentLoaded}" Value="True">
@@ -273,8 +293,8 @@
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
-                                </FlowDocumentScrollViewer.Style>
-                            </FlowDocumentScrollViewer>
+                                </controls:HighlightingFlowDocumentScrollViewer.Style>
+                            </controls:HighlightingFlowDocumentScrollViewer>
                             <TextBlock Grid.Row="3"
                                        Margin="0,20,0,0"
                                        Text="Open a document to preview its contents here."


### PR DESCRIPTION
## Summary
- add a FlowDocument viewer control that highlights the active narration segment
- extend the document reader view model with highlight state, settings persistence, and customizable colors
- update the UI to expose highlight color selection and default to the current theme accent color

## Testing
- `dotnet build Dissonance/Dissonance.sln` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16840c90c832da803b32c67105976