### PR TITLE
Add document progress persistence setting

### DIFF
--- a/Dissonance/Dissonance.Tests/Services/SettingsServiceTests.cs
+++ b/Dissonance/Dissonance.Tests/Services/SettingsServiceTests.cs
@@ -33,6 +33,9 @@ namespace Dissonance.Tests.Services
                         Assert.Null(settings.WindowWidth);
                         Assert.Null(settings.WindowHeight);
                         Assert.False(settings.IsWindowMaximized);
+                        Assert.False(settings.RememberDocumentProgress);
+                        Assert.Null(settings.DocumentReaderLastFilePath);
+                        Assert.Null(settings.DocumentReaderLastCharacterIndex);
                         Assert.Equal("Alt", settings.Hotkey.Modifiers);
                         Assert.Equal("E", settings.Hotkey.Key);
 
@@ -51,6 +54,9 @@ namespace Dissonance.Tests.Services
                         Assert.Equal(settings.WindowWidth, storedSettings.WindowWidth);
                         Assert.Equal(settings.WindowHeight, storedSettings.WindowHeight);
                         Assert.Equal(settings.IsWindowMaximized, storedSettings.IsWindowMaximized);
+                        Assert.Equal(settings.RememberDocumentProgress, storedSettings.RememberDocumentProgress);
+                        Assert.Equal(settings.DocumentReaderLastFilePath, storedSettings.DocumentReaderLastFilePath);
+                        Assert.Equal(settings.DocumentReaderLastCharacterIndex, storedSettings.DocumentReaderLastCharacterIndex);
                         Assert.Equal(settings.Hotkey.Modifiers, storedSettings.Hotkey!.Modifiers);
                         Assert.Equal(settings.Hotkey.Key, storedSettings.Hotkey.Key);
 
@@ -82,7 +88,10 @@ namespace Dissonance.Tests.Services
                                 {
                                         Modifiers = string.Empty,
                                         Key = string.Empty,
-                                }
+                                },
+                                RememberDocumentProgress = true,
+                                DocumentReaderLastFilePath = " ",
+                                DocumentReaderLastCharacterIndex = -10,
                         };
 
                         service.SaveSettings(invalidSettings);
@@ -99,6 +108,9 @@ namespace Dissonance.Tests.Services
                         Assert.Null(current.WindowWidth);
                         Assert.Null(current.WindowHeight);
                         Assert.True(current.IsWindowMaximized);
+                        Assert.True(current.RememberDocumentProgress);
+                        Assert.Null(current.DocumentReaderLastFilePath);
+                        Assert.Null(current.DocumentReaderLastCharacterIndex);
                         Assert.Equal("Alt", current.Hotkey.Modifiers);
                         Assert.Equal("E", current.Hotkey.Key);
 
@@ -115,6 +127,9 @@ namespace Dissonance.Tests.Services
                         Assert.Equal(current.WindowWidth, storedSettings.WindowWidth);
                         Assert.Equal(current.WindowHeight, storedSettings.WindowHeight);
                         Assert.Equal(current.IsWindowMaximized, storedSettings.IsWindowMaximized);
+                        Assert.Equal(current.RememberDocumentProgress, storedSettings.RememberDocumentProgress);
+                        Assert.Equal(current.DocumentReaderLastFilePath, storedSettings.DocumentReaderLastFilePath);
+                        Assert.Equal(current.DocumentReaderLastCharacterIndex, storedSettings.DocumentReaderLastCharacterIndex);
                         Assert.Equal(current.Hotkey.Modifiers, storedSettings.Hotkey!.Modifiers);
                         Assert.Equal(current.Hotkey.Key, storedSettings.Hotkey.Key);
 
@@ -145,7 +160,10 @@ namespace Dissonance.Tests.Services
                                 {
                                         Modifiers = "Ctrl+Shift",
                                         Key = "H",
-                                }
+                                },
+                                RememberDocumentProgress = true,
+                                DocumentReaderLastFilePath = "notes.txt",
+                                DocumentReaderLastCharacterIndex = 42,
                         };
 
                         service.SaveSettings(desiredSettings);
@@ -164,6 +182,9 @@ namespace Dissonance.Tests.Services
                         Assert.Equal(desiredSettings.WindowWidth, current.WindowWidth);
                         Assert.Equal(desiredSettings.WindowHeight, current.WindowHeight);
                         Assert.Equal(desiredSettings.IsWindowMaximized, current.IsWindowMaximized);
+                        Assert.Equal(desiredSettings.RememberDocumentProgress, current.RememberDocumentProgress);
+                        Assert.Equal(desiredSettings.DocumentReaderLastFilePath, current.DocumentReaderLastFilePath);
+                        Assert.Equal(desiredSettings.DocumentReaderLastCharacterIndex, current.DocumentReaderLastCharacterIndex);
                         Assert.Equal(desiredSettings.Hotkey!.Modifiers, current.Hotkey.Modifiers);
                         Assert.Equal(desiredSettings.Hotkey.Key, current.Hotkey.Key);
 
@@ -181,6 +202,9 @@ namespace Dissonance.Tests.Services
                         Assert.Equal(desiredSettings.WindowWidth, defaultSettings.WindowWidth);
                         Assert.Equal(desiredSettings.WindowHeight, defaultSettings.WindowHeight);
                         Assert.Equal(desiredSettings.IsWindowMaximized, defaultSettings.IsWindowMaximized);
+                        Assert.Equal(desiredSettings.RememberDocumentProgress, defaultSettings.RememberDocumentProgress);
+                        Assert.Equal(desiredSettings.DocumentReaderLastFilePath, defaultSettings.DocumentReaderLastFilePath);
+                        Assert.Equal(desiredSettings.DocumentReaderLastCharacterIndex, defaultSettings.DocumentReaderLastCharacterIndex);
                         Assert.Equal(desiredSettings.Hotkey.Modifiers, defaultSettings.Hotkey!.Modifiers);
                         Assert.Equal(desiredSettings.Hotkey.Key, defaultSettings.Hotkey.Key);
 
@@ -197,6 +221,9 @@ namespace Dissonance.Tests.Services
                         Assert.Equal(desiredSettings.WindowWidth, storedSettings.WindowWidth);
                         Assert.Equal(desiredSettings.WindowHeight, storedSettings.WindowHeight);
                         Assert.Equal(desiredSettings.IsWindowMaximized, storedSettings.IsWindowMaximized);
+                        Assert.Equal(desiredSettings.RememberDocumentProgress, storedSettings.RememberDocumentProgress);
+                        Assert.Equal(desiredSettings.DocumentReaderLastFilePath, storedSettings.DocumentReaderLastFilePath);
+                        Assert.Equal(desiredSettings.DocumentReaderLastCharacterIndex, storedSettings.DocumentReaderLastCharacterIndex);
                         Assert.Equal(desiredSettings.Hotkey.Modifiers, storedSettings.Hotkey!.Modifiers);
                         Assert.Equal(desiredSettings.Hotkey.Key, storedSettings.Hotkey.Key);
 
@@ -228,7 +255,10 @@ namespace Dissonance.Tests.Services
                                 {
                                         Modifiers = "Ctrl",
                                         Key = "K",
-                                }
+                                },
+                                RememberDocumentProgress = true,
+                                DocumentReaderLastFilePath = "custom.txt",
+                                DocumentReaderLastCharacterIndex = 10,
                         };
 
                         service.SaveSettings(customSettings);
@@ -246,6 +276,9 @@ namespace Dissonance.Tests.Services
                         Assert.Null(current.WindowWidth);
                         Assert.Null(current.WindowHeight);
                         Assert.False(current.IsWindowMaximized);
+                        Assert.False(current.RememberDocumentProgress);
+                        Assert.Null(current.DocumentReaderLastFilePath);
+                        Assert.Null(current.DocumentReaderLastCharacterIndex);
                         Assert.Equal("Alt", current.Hotkey.Modifiers);
                         Assert.Equal("E", current.Hotkey.Key);
 
@@ -262,6 +295,9 @@ namespace Dissonance.Tests.Services
                         Assert.Null(storedSettings.WindowWidth);
                         Assert.Null(storedSettings.WindowHeight);
                         Assert.False(storedSettings.IsWindowMaximized);
+                        Assert.False(storedSettings.RememberDocumentProgress);
+                        Assert.Null(storedSettings.DocumentReaderLastFilePath);
+                        Assert.Null(storedSettings.DocumentReaderLastCharacterIndex);
                         Assert.Equal("Alt", storedSettings.Hotkey!.Modifiers);
                         Assert.Equal("E", storedSettings.Hotkey.Key);
 

--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -202,7 +202,10 @@ namespace Dissonance.Tests.ViewModels
                                         Key = "MediaPlayPause",
                                         Modifiers = string.Empty,
                                         UsePlayPauseToggle = false,
-                                }
+                                },
+                                RememberDocumentProgress = false,
+                                DocumentReaderLastFilePath = null,
+                                DocumentReaderLastCharacterIndex = null,
                         };
 
                         var settingsService = new TestSettingsService(settings);
@@ -325,7 +328,10 @@ namespace Dissonance.Tests.ViewModels
                                                 Modifiers = settings.DocumentReaderHotkey?.Modifiers ?? string.Empty,
                                                 Key = settings.DocumentReaderHotkey?.Key ?? string.Empty,
                                                 UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? false,
-                                        }
+                                        },
+                                        RememberDocumentProgress = settings.RememberDocumentProgress,
+                                        DocumentReaderLastFilePath = settings.DocumentReaderLastFilePath,
+                                        DocumentReaderLastCharacterIndex = settings.DocumentReaderLastCharacterIndex,
                                 };
                         }
                 }

--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -28,6 +28,12 @@ namespace Dissonance
 
                 public bool IsWindowMaximized { get; set; }
 
+                public bool RememberDocumentProgress { get; set; }
+
+                public string? DocumentReaderLastFilePath { get; set; }
+
+                public int? DocumentReaderLastCharacterIndex { get; set; }
+
                 public class HotkeySettings
                 {
                         public string Key { get; set; }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -179,6 +179,9 @@ namespace Dissonance.Services.SettingsService
                                 Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
                                 DocumentReaderHotkey = new DocumentReaderHotkeySettings { Modifiers = string.Empty, Key = "MediaPlayPause", UsePlayPauseToggle = false },
                                 DocumentReaderHighlightColor = "ThemeAccent",
+                                RememberDocumentProgress = false,
+                                DocumentReaderLastFilePath = null,
+                                DocumentReaderLastCharacterIndex = null,
                         };
                 }
 
@@ -208,7 +211,10 @@ namespace Dissonance.Services.SettingsService
                                         Key = settings.DocumentReaderHotkey?.Key ?? string.Empty,
                                         UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? false,
                                 },
-                                DocumentReaderHighlightColor = settings.DocumentReaderHighlightColor
+                                DocumentReaderHighlightColor = settings.DocumentReaderHighlightColor,
+                                RememberDocumentProgress = settings.RememberDocumentProgress,
+                                DocumentReaderLastFilePath = settings.DocumentReaderLastFilePath,
+                                DocumentReaderLastCharacterIndex = settings.DocumentReaderLastCharacterIndex,
                         };
                 }
 
@@ -243,9 +249,20 @@ namespace Dissonance.Services.SettingsService
                                         UsePlayPauseToggle = settings.DocumentReaderHotkey?.UsePlayPauseToggle ?? reference.DocumentReaderHotkey.UsePlayPauseToggle,
                                 },
                                 DocumentReaderHighlightColor = string.IsNullOrWhiteSpace ( settings.DocumentReaderHighlightColor ) ? reference.DocumentReaderHighlightColor : settings.DocumentReaderHighlightColor,
+                                RememberDocumentProgress = settings.RememberDocumentProgress,
+                                DocumentReaderLastFilePath = string.IsNullOrWhiteSpace ( settings.DocumentReaderLastFilePath ) ? null : settings.DocumentReaderLastFilePath,
+                                DocumentReaderLastCharacterIndex = NormalizeCharacterIndex ( settings.DocumentReaderLastCharacterIndex, reference.DocumentReaderLastCharacterIndex ),
                         };
 
                         return normalized;
+                }
+
+                private static int? NormalizeCharacterIndex ( int? value, int? fallback )
+                {
+                        if ( value.HasValue && value.Value >= 0 )
+                                return value.Value;
+
+                        return fallback;
                 }
 
                 private static double? NormalizeDimension ( double? value, double? fallback )

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -127,65 +127,128 @@
 
                     <Border Grid.Column="0"
                             Style="{StaticResource CardContainerStyle}">
-                        <StackPanel>
-                            <TextBlock Text="Document details"
-                                       Style="{StaticResource CardTitleTextStyle}"/>
-                            <TextBlock Text="Supported format: plain text (.txt)"
-                                       Style="{StaticResource CardDescriptionTextStyle}"
-                                       Margin="0,6,0,0"/>
-                            <TextBlock Text="Selected file"
-                                       FontWeight="SemiBold"
-                                       Margin="0,16,0,0"/>
-                            <TextBox Style="{StaticResource ModernTextBoxStyle}"
-                                     Text="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"
-                                     IsReadOnly="True"
-                                     Margin="0,8,0,0"
-                                     HorizontalAlignment="Stretch"
-                                     TextWrapping="Wrap"
-                                     MinHeight="34"/>
-                            <Grid Margin="0,16,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Grid.Column="0">
-                                    <TextBlock Text="Words"
-                                               Style="{StaticResource CardDescriptionTextStyle}"/>
-                                    <TextBlock Text="{Binding WordCount, StringFormat={}{0:N0}}"
-                                               Style="{StaticResource ValueBadgeTextStyle}"
-                                               Margin="0,6,0,0"/>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <StackPanel Grid.Row="0">
+                                <TextBlock Text="Document details"
+                                           Style="{StaticResource CardTitleTextStyle}"/>
+                                <TextBlock Text="Supported format: plain text (.txt)"
+                                           Style="{StaticResource CardDescriptionTextStyle}"
+                                           Margin="0,6,0,0"/>
+                                <TextBlock Text="Selected file"
+                                           FontWeight="SemiBold"
+                                           Margin="0,16,0,0"/>
+                                <TextBox Style="{StaticResource ModernTextBoxStyle}"
+                                         Text="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"
+                                         IsReadOnly="True"
+                                         Margin="0,8,0,0"
+                                         HorizontalAlignment="Stretch"
+                                         TextWrapping="Wrap"
+                                         MinHeight="34"/>
+                                <Grid Margin="0,16,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Column="0">
+                                        <TextBlock Text="Words"
+                                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                                        <TextBlock Text="{Binding WordCount, StringFormat={}{0:N0}}"
+                                                   Style="{StaticResource ValueBadgeTextStyle}"
+                                                   Margin="0,6,0,0"/>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1">
+                                        <TextBlock Text="Characters"
+                                                   Style="{StaticResource CardDescriptionTextStyle}"/>
+                                        <TextBlock Text="{Binding CharacterCount, StringFormat={}{0:N0}}"
+                                                   Style="{StaticResource ValueBadgeTextStyle}"
+                                                   Margin="0,6,0,0"/>
+                                    </StackPanel>
+                                </Grid>
+                            </StackPanel>
+                            <ScrollViewer Grid.Row="1"
+                                          Margin="0,24,0,0"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <StackPanel>
+                                    <TextBlock x:Name="PlaybackHotkeyHeading"
+                                               Text="Playback hotkey"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                    <TextBlock Margin="0,4,0,0"
+                                               Text="Assign a shortcut to control document narration while reviewing the preview."
+                                               Style="{StaticResource CardDescriptionTextStyle}"
+                                               TextWrapping="Wrap"/>
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="0,8,0,0">
+                                        <TextBox x:Name="DocumentPlaybackHotkeyTextBox"
+                                                 Width="180"
+                                                 Style="{StaticResource ModernTextBoxStyle}"
+                                                 Text="{Binding PlaybackHotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 IsReadOnly="True"
+                                                 PreviewKeyDown="DocumentPlaybackHotkeyTextBox_PreviewKeyDown"
+                                                 AutomationProperties.LabeledBy="{Binding ElementName=PlaybackHotkeyHeading}"
+                                                 AutomationProperties.Name="Document playback hotkey"
+                                                 AutomationProperties.HelpText="Set the hotkey used to play or stop document narration while reviewing the preview."/>
+                                        <Button Content="Apply"
+                                                Style="{StaticResource PrimaryButtonStyle}"
+                                                Command="{Binding ApplyPlaybackHotkeyCommand}"
+                                                Margin="12,0,0,0"
+                                                MinWidth="96"
+                                                AutomationProperties.Name="Apply document playback hotkey"
+                                                AutomationProperties.HelpText="Applies the document playback hotkey combination"/>
+                                    </StackPanel>
+                                    <CheckBox Margin="0,12,0,0"
+                                              Content="Use the hotkey to play and pause instead of stopping"
+                                              Style="{StaticResource MenuCheckBoxStyle}"
+                                              IsChecked="{Binding PlaybackHotkeyTogglesPause, Mode=TwoWay}"
+                                              ToolTip="When enabled, pressing the hotkey toggles between play and pause."
+                                              AutomationProperties.Name="Toggle playback hotkey pause behavior"
+                                              AutomationProperties.HelpText="Enable to make the playback hotkey pause and resume the document preview"/>
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="0,16,0,0"
+                                                VerticalAlignment="Center">
+                                        <TextBlock Text="Highlight color"
+                                                   Margin="0,0,12,0"
+                                                   VerticalAlignment="Center"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                        <ComboBox ItemsSource="{Binding HighlightColorOptions}"
+                                                  SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
+                                                  DisplayMemberPath="DisplayName"
+                                                  MinWidth="200"
+                                                  Style="{StaticResource HighlightColorComboBoxStyle}"
+                                                  AutomationProperties.Name="Document highlight color"
+                                                  AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
+                                    </StackPanel>
+                                    <TextBlock Text="{Binding StatusMessage}"
+                                               Margin="0,20,0,0"
+                                               TextWrapping="Wrap"
+                                               Foreground="{DynamicResource AccentBrush}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <CheckBox Margin="0,16,0,0"
+                                              Content="Remember this document and position"
+                                              Style="{StaticResource MenuCheckBoxStyle}"
+                                              IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
+                                              ToolTip="Automatically reopen the last document and resume from the saved location."
+                                              AutomationProperties.Name="Remember document progress toggle"
+                                              AutomationProperties.HelpText="Enable to reopen the last document automatically and continue where you stopped."/>
                                 </StackPanel>
-                                <StackPanel Grid.Column="1">
-                                    <TextBlock Text="Characters"
-                                               Style="{StaticResource CardDescriptionTextStyle}"/>
-                                    <TextBlock Text="{Binding CharacterCount, StringFormat={}{0:N0}}"
-                                               Style="{StaticResource ValueBadgeTextStyle}"
-                                               Margin="0,6,0,0"/>
-                                </StackPanel>
-                            </Grid>
-                            <TextBlock Text="{Binding StatusMessage}"
-                                       Margin="0,20,0,0"
-                                       TextWrapping="Wrap"
-                                       Foreground="{DynamicResource AccentBrush}">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                            <CheckBox Margin="0,16,0,0"
-                                      Content="Remember this document and position"
-                                      Style="{StaticResource MenuCheckBoxStyle}"
-                                      IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
-                                      ToolTip="Automatically reopen the last document and resume from the saved location."
-                                      AutomationProperties.Name="Remember document progress toggle"
-                                      AutomationProperties.HelpText="Enable to reopen the last document automatically and continue where you stopped."/>
-                        </StackPanel>
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
 
                     <Border Grid.Column="1"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -220,7 +220,7 @@
                                                   SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
                                                   DisplayMemberPath="DisplayName"
                                                   MinWidth="200"
-                                                  Style="{StaticResource HighlightColorComboBoxStyle}"
+                                                  Style="{StaticResource ModernComboBoxStyle}"
                                                   AutomationProperties.Name="Document highlight color"
                                                   AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
                                     </StackPanel>
@@ -261,7 +261,6 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <TextBlock Text="Document preview"
@@ -294,60 +293,7 @@
                                         IsEnabled="{Binding IsDocumentLoaded}"
                                         AutomationProperties.Name="Fast forward 10 seconds"/>
                             </StackPanel>
-                            <StackPanel Grid.Row="2"
-                                        Margin="0,16,0,0">
-                                <TextBlock x:Name="PlaybackHotkeyHeading"
-                                           Text="Playback hotkey"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                                <TextBlock Margin="0,4,0,0"
-                                           Text="Assign a shortcut to control document narration while reviewing the preview."
-                                           Style="{StaticResource CardDescriptionTextStyle}"
-                                           TextWrapping="Wrap"/>
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="0,8,0,0">
-                                    <TextBox x:Name="DocumentPlaybackHotkeyTextBox"
-                                             Width="180"
-                                             Style="{StaticResource ModernTextBoxStyle}"
-                                             Text="{Binding PlaybackHotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                             IsReadOnly="True"
-                                             PreviewKeyDown="DocumentPlaybackHotkeyTextBox_PreviewKeyDown"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=PlaybackHotkeyHeading}"
-                                             AutomationProperties.Name="Document playback hotkey"
-                                             AutomationProperties.HelpText="Set the hotkey used to play or stop document narration"/>
-                                    <Button Content="Apply"
-                                            Style="{StaticResource PrimaryButtonStyle}"
-                                            Command="{Binding ApplyPlaybackHotkeyCommand}"
-                                            Margin="12,0,0,0"
-                                            MinWidth="96"
-                                            AutomationProperties.Name="Apply document playback hotkey"
-                                            AutomationProperties.HelpText="Applies the document playback hotkey combination"/>
-                                </StackPanel>
-                                <CheckBox Margin="0,12,0,0"
-                                          Content="Use the hotkey to play and pause instead of stopping"
-                                          Style="{StaticResource MenuCheckBoxStyle}"
-                                          IsChecked="{Binding PlaybackHotkeyTogglesPause, Mode=TwoWay}"
-                                          ToolTip="When enabled, pressing the hotkey toggles between play and pause."
-                                          AutomationProperties.Name="Toggle playback hotkey pause behavior"
-                                          AutomationProperties.HelpText="Enable to make the playback hotkey pause and resume the document preview"/>
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="0,16,0,0"
-                                            VerticalAlignment="Center">
-                                    <TextBlock Text="Highlight color"
-                                               Margin="0,0,12,0"
-                                               VerticalAlignment="Center"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                                    <ComboBox ItemsSource="{Binding HighlightColorOptions}"
-                                              SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
-                                              DisplayMemberPath="DisplayName"
-                                              Width="200"
-                                              Style="{StaticResource ModernComboBoxStyle}"
-                                              AutomationProperties.Name="Document highlight color"
-                                              AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
-                                </StackPanel>
-                            </StackPanel>
-                            <controls:HighlightingFlowDocumentScrollViewer Grid.Row="3"
+                            <controls:HighlightingFlowDocumentScrollViewer Grid.Row="2"
                                                                               Margin="0,12,0,0"
                                                                               Document="{Binding Document}"
                                                                               HighlightStartIndex="{Binding HighlightStartIndex}"
@@ -365,7 +311,7 @@
                                     </Style>
                                 </controls:HighlightingFlowDocumentScrollViewer.Style>
                             </controls:HighlightingFlowDocumentScrollViewer>
-                            <TextBlock Grid.Row="3"
+                            <TextBlock Grid.Row="2"
                                        Margin="0,20,0,0"
                                        Text="Open a document to preview its contents here."
                                        HorizontalAlignment="Center"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -178,6 +178,13 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
+                            <CheckBox Margin="0,16,0,0"
+                                      Content="Remember this document and position"
+                                      Style="{StaticResource MenuCheckBoxStyle}"
+                                      IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
+                                      ToolTip="Automatically reopen the last document and resume from the saved location."
+                                      AutomationProperties.Name="Remember document progress toggle"
+                                      AutomationProperties.HelpText="Enable to reopen the last document automatically and continue where you stopped."/>
                         </StackPanel>
                     </Border>
 


### PR DESCRIPTION
## Summary
- add persisted settings to store the last opened document and playback position when enabled
- extend the document reader view model and UI to toggle remembering progress and to automatically restore saved state
- update settings defaults and automated tests to cover the new document progress features

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17ae05298832d97101a6402ac753f