### PR TITLE
Add dedicated reader settings section

### DIFF
--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -40,6 +40,7 @@ namespace Dissonance.ViewModels
                 private readonly ObservableCollection<StatusAnnouncement> _statusHistory = new ObservableCollection<StatusAnnouncement> ( );
                 private readonly ReadOnlyObservableCollection<StatusAnnouncement> _statusHistoryView;
                 private readonly DocumentReaderViewModel _documentReaderViewModel;
+                private readonly ReaderSettingsViewModel _readerSettingsViewModel;
                 private bool _isDarkTheme;
                 private bool _isNavigationMenuOpen;
                 private string _hotkeyCombination = string.Empty;
@@ -138,12 +139,23 @@ namespace Dissonance.ViewModels
                         OnPropertyChanged ( nameof ( CurrentThemeName ) );
                         OnPropertyChanged ( nameof ( SaveConfigAsDefaultOnClose ) );
 
+                        _readerSettingsViewModel = new ReaderSettingsViewModel ( this );
+
+                        _navigationSections.Add ( new NavigationSectionViewModel (
+                                "reader-settings",
+                                "Reader Settings",
+                                "Control the voice, speed, and volume shared across narration tools.",
+                                "Reader Settings",
+                                "Adjust text-to-speech preferences used throughout Dissonance.",
+                                _readerSettingsViewModel,
+                                showSettingsControls: true ) );
+
                         _navigationSections.Add ( new NavigationSectionViewModel (
                                 "clipboard-reader",
                                 "Clipboard Reader",
                                 "Instantly speak the text you've copied to the clipboard.",
                                 "Clipboard Reader",
-                                "Fine-tune speech playback, volume, and shortcuts for the clipboard narration experience.",
+                                "Customize shortcuts and playback behavior for clipboard narration.",
                                 this,
                                 showSettingsControls: true ) );
 
@@ -161,6 +173,8 @@ namespace Dissonance.ViewModels
                 public ObservableCollection<string> AvailableVoices { get; } = new ObservableCollection<string> ( );
 
                 public ObservableCollection<NavigationSectionViewModel> NavigationSections => _navigationSections;
+
+                public ReaderSettingsViewModel ReaderSettings => _readerSettingsViewModel;
 
                 public DocumentReaderViewModel DocumentReader => _documentReaderViewModel;
 
@@ -367,6 +381,7 @@ namespace Dissonance.ViewModels
                 {
                         _statusAnnouncementService.StatusAnnounced -= OnStatusAnnounced;
                         _ttsService.SpeechCompleted -= OnSpeechCompleted;
+                        _readerSettingsViewModel.Dispose ( );
                         SetPreviewState ( false, null );
                         _ttsService.Stop ( );
 

--- a/Dissonance/Dissonance/ViewModels/ReaderSettingsViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/ReaderSettingsViewModel.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace Dissonance.ViewModels
+{
+        public class ReaderSettingsViewModel : INotifyPropertyChanged, IDisposable
+        {
+                private readonly MainWindowViewModel _mainViewModel;
+                private bool _isDisposed;
+
+                public ReaderSettingsViewModel ( MainWindowViewModel mainViewModel )
+                {
+                        _mainViewModel = mainViewModel ?? throw new ArgumentNullException ( nameof ( mainViewModel ) );
+                        _mainViewModel.PropertyChanged += OnParentPropertyChanged;
+                }
+
+                public ObservableCollection<string> AvailableVoices => _mainViewModel.AvailableVoices;
+
+                public string Voice
+                {
+                        get => _mainViewModel.Voice;
+                        set => _mainViewModel.Voice = value;
+                }
+
+                public double VoiceRate
+                {
+                        get => _mainViewModel.VoiceRate;
+                        set => _mainViewModel.VoiceRate = value;
+                }
+
+                public int Volume
+                {
+                        get => _mainViewModel.Volume;
+                        set => _mainViewModel.Volume = value;
+                }
+
+                public ICommand PreviewVoiceCommand => _mainViewModel.PreviewVoiceCommand;
+
+                public string PreviewVoiceButtonLabel => _mainViewModel.PreviewVoiceButtonLabel;
+
+                public string PreviewVoiceButtonToolTip => _mainViewModel.PreviewVoiceButtonToolTip;
+
+                public string PreviewVoiceHelpText => _mainViewModel.PreviewVoiceHelpText;
+
+                public bool IsPreviewing => _mainViewModel.IsPreviewing;
+
+                public event PropertyChangedEventHandler? PropertyChanged;
+
+                private void OnParentPropertyChanged ( object? sender, PropertyChangedEventArgs e )
+                {
+                        if ( string.IsNullOrEmpty ( e.PropertyName ) )
+                        {
+                                OnPropertyChanged ( nameof ( Voice ) );
+                                OnPropertyChanged ( nameof ( VoiceRate ) );
+                                OnPropertyChanged ( nameof ( Volume ) );
+                                OnPropertyChanged ( nameof ( PreviewVoiceButtonLabel ) );
+                                OnPropertyChanged ( nameof ( PreviewVoiceButtonToolTip ) );
+                                OnPropertyChanged ( nameof ( PreviewVoiceHelpText ) );
+                                OnPropertyChanged ( nameof ( IsPreviewing ) );
+                                return;
+                        }
+
+                        switch ( e.PropertyName )
+                        {
+                                case nameof ( MainWindowViewModel.Voice ):
+                                        OnPropertyChanged ( nameof ( Voice ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.VoiceRate ):
+                                        OnPropertyChanged ( nameof ( VoiceRate ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.Volume ):
+                                        OnPropertyChanged ( nameof ( Volume ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.IsPreviewing ):
+                                        OnPropertyChanged ( nameof ( IsPreviewing ) );
+                                        OnPropertyChanged ( nameof ( PreviewVoiceButtonLabel ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.PreviewVoiceButtonLabel ):
+                                        OnPropertyChanged ( nameof ( PreviewVoiceButtonLabel ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.PreviewVoiceButtonToolTip ):
+                                        OnPropertyChanged ( nameof ( PreviewVoiceButtonToolTip ) );
+                                        break;
+                                case nameof ( MainWindowViewModel.PreviewVoiceHelpText ):
+                                        OnPropertyChanged ( nameof ( PreviewVoiceHelpText ) );
+                                        break;
+                        }
+                }
+
+                protected virtual void OnPropertyChanged ( string propertyName )
+                {
+                        PropertyChanged?.Invoke ( this, new PropertyChangedEventArgs ( propertyName ) );
+                }
+
+                public void Dispose ( )
+                {
+                        if ( _isDisposed )
+                                return;
+
+                        _mainViewModel.PropertyChanged -= OnParentPropertyChanged;
+                        _isDisposed = true;
+                }
+        }
+}

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -318,13 +318,9 @@
                 </Grid>
             </Grid>
         </DataTemplate>
-        <DataTemplate DataType="{x:Type local:NavigationSectionViewModel}">
-            <ContentPresenter Content="{Binding ContentViewModel}"/>
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type local:MainWindowViewModel}">
+        <DataTemplate DataType="{x:Type local:ReaderSettingsViewModel}">
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
@@ -362,7 +358,7 @@
                                       SelectedItem="{Binding Voice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       AutomationProperties.LabeledBy="{Binding ElementName=VoiceSelectionHeading}"
                                       ToolTip="Select the voice used by the text-to-speech engine"
-                                      TabIndex="2"
+                                      TabIndex="0"
                                       HorizontalAlignment="Stretch"
                                       MinWidth="220"
                                       MinHeight="34"/>
@@ -375,7 +371,7 @@
                                     ToolTip="{Binding PreviewVoiceButtonToolTip}"
                                     AutomationProperties.Name="{Binding PreviewVoiceButtonLabel}"
                                     AutomationProperties.HelpText="{Binding PreviewVoiceHelpText}"
-                                    TabIndex="3"/>
+                                    TabIndex="1"/>
                         </Grid>
                     </Grid>
                 </Border>
@@ -407,8 +403,8 @@
                                  ToolTip="Set the speaking rate of the text-to-speech voice"
                                  HorizontalAlignment="Left"
                                  HorizontalContentAlignment="Center"
-                                  Width="140"
-                                 TabIndex="4"
+                                 Width="140"
+                                 TabIndex="2"
                                  AutomationProperties.HelpText="Enter a numeric value to control how fast the voice speaks"/>
                     </StackPanel>
                 </Border>
@@ -416,7 +412,8 @@
                 <Border Style="{StaticResource CardContainerStyle}"
                         Grid.Row="1"
                         Grid.Column="0"
-                        Margin="0,12,12,0">
+                        Grid.ColumnSpan="2"
+                        Margin="0,12,0,0">
                     <StackPanel>
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -445,7 +442,7 @@
                                 AutomationProperties.HelpText="Use the arrow keys to adjust the speech output volume"
                                 Focusable="True"
                                 IsTabStop="True"
-                                TabIndex="5"
+                                TabIndex="3"
                                 KeyDown="VoiceVolumeSlider_KeyDown">
                             <Slider.ToolTip>
                                 <ToolTip>
@@ -458,11 +455,15 @@
                         </Slider>
                     </StackPanel>
                 </Border>
-
+            </Grid>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type local:NavigationSectionViewModel}">
+            <ContentPresenter Content="{Binding ContentViewModel}"/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type local:MainWindowViewModel}">
+            <Grid>
                 <Border Style="{StaticResource CardContainerStyle}"
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Margin="12,12,0,0">
+                        Margin="0">
                     <StackPanel>
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -507,7 +508,7 @@
                                          Text="{Binding HotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                          AutomationProperties.LabeledBy="{Binding ElementName=HotkeyHeading}"
                                          ToolTip="Set the hotkey used to copy the current selection and speak it aloud"
-                                         TabIndex="6"
+                                         TabIndex="0"
                                          IsReadOnly="True"
                                          PreviewKeyDown="ReadClipboardHotkeyTextBox_PreviewKeyDown"
                                          AutomationProperties.HelpText="Specify the key combination that copies the current selection and speaks it aloud"/>
@@ -517,7 +518,7 @@
                                         Margin="12,0,0,0"
                                         MinWidth="96"
                                         ToolTip="Apply the new hotkey immediately"
-                                        TabIndex="7"
+                                        TabIndex="1"
                                         AutomationProperties.Name="Apply hotkey"
                                         AutomationProperties.HelpText="Applies the entered hotkey combination"/>
                             </StackPanel>
@@ -558,7 +559,7 @@
                                               AutomationProperties.Name="Automatically speak new clipboard text"
                                               AutomationProperties.HelpText="When enabled, clipboard text will be spoken immediately after it changes"
                                               AutomationProperties.LabeledBy="{Binding ElementName=AutoReadToggleLabel}"
-                                              TabIndex="5"/>
+                                              TabIndex="2"/>
                             </Grid>
                         </Border>
 


### PR DESCRIPTION
## Summary
- introduce a ReaderSettingsViewModel that exposes shared voice, rate, and volume controls
- add a Reader Settings navigation tile and update clipboard section messaging
- move the voice configuration UI into its own template and streamline the clipboard section layout

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e17b4b1844832dbd464d40019ed65b