### PR TITLE
Add document resume setting and persist reader progress

### DIFF
--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -28,6 +28,12 @@ namespace Dissonance
 
                 public bool IsWindowMaximized { get; set; }
 
+                public bool RememberDocumentReaderPosition { get; set; }
+
+                public string? DocumentReaderLastFilePath { get; set; }
+
+                public int DocumentReaderLastCharacterIndex { get; set; }
+
                 public class HotkeySettings
                 {
                         public string Key { get; set; }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -176,6 +176,9 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = null,
                                 WindowHeight = null,
                                 IsWindowMaximized = false,
+                                RememberDocumentReaderPosition = false,
+                                DocumentReaderLastFilePath = null,
+                                DocumentReaderLastCharacterIndex = 0,
                                 Hotkey = new HotkeySettings { Modifiers = "Alt", Key = "E", AutoReadClipboard = false },
                                 DocumentReaderHotkey = new DocumentReaderHotkeySettings { Modifiers = string.Empty, Key = "MediaPlayPause", UsePlayPauseToggle = false },
                                 DocumentReaderHighlightColor = "ThemeAccent",
@@ -196,6 +199,9 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = settings.WindowWidth,
                                 WindowHeight = settings.WindowHeight,
                                 IsWindowMaximized = settings.IsWindowMaximized,
+                                RememberDocumentReaderPosition = settings.RememberDocumentReaderPosition,
+                                DocumentReaderLastFilePath = settings.DocumentReaderLastFilePath,
+                                DocumentReaderLastCharacterIndex = settings.DocumentReaderLastCharacterIndex,
                                 Hotkey = new HotkeySettings
                                 {
                                         Modifiers = settings.Hotkey?.Modifiers ?? string.Empty,
@@ -230,6 +236,9 @@ namespace Dissonance.Services.SettingsService
                                 WindowWidth = NormalizeDimension ( settings.WindowWidth, reference.WindowWidth ),
                                 WindowHeight = NormalizeDimension ( settings.WindowHeight, reference.WindowHeight ),
                                 IsWindowMaximized = settings.IsWindowMaximized,
+                                RememberDocumentReaderPosition = settings.RememberDocumentReaderPosition,
+                                DocumentReaderLastFilePath = string.IsNullOrWhiteSpace ( settings.DocumentReaderLastFilePath ) ? reference.DocumentReaderLastFilePath : settings.DocumentReaderLastFilePath,
+                                DocumentReaderLastCharacterIndex = settings.DocumentReaderLastCharacterIndex < 0 ? reference.DocumentReaderLastCharacterIndex : settings.DocumentReaderLastCharacterIndex,
                                 Hotkey = new HotkeySettings
                                 {
                                         Modifiers = string.IsNullOrWhiteSpace ( settings.Hotkey?.Modifiers ) ? reference.Hotkey.Modifiers : settings.Hotkey.Modifiers,

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -148,6 +148,42 @@
                                          HorizontalAlignment="Stretch"
                                          TextWrapping="Wrap"
                                          MinHeight="34"/>
+                                <Border Margin="0,16,0,0"
+                                        Padding="12"
+                                        Background="{DynamicResource SurfaceBackgroundBrush}"
+                                        BorderBrush="{DynamicResource CardBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0"
+                                                    Orientation="Vertical"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    MaxWidth="240">
+                                            <TextBlock x:Name="RememberDocumentToggleLabel"
+                                                       Text="Remember document progress"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                            <TextBlock Margin="0,4,0,0"
+                                                       Text="Reopen the last document and resume where you left off."
+                                                       Style="{StaticResource CardDescriptionTextStyle}"
+                                                       TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <ToggleButton Grid.Column="1"
+                                                      Style="{StaticResource SettingsToggleSwitchStyle}"
+                                                      IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
+                                                      VerticalAlignment="Center"
+                                                      Margin="16,0,0,0"
+                                                      AutomationProperties.Name="Remember the last document and position"
+                                                      AutomationProperties.HelpText="When enabled, Dissonance reopens the last document and restores the saved reading position."
+                                                      AutomationProperties.LabeledBy="{Binding ElementName=RememberDocumentToggleLabel}"/>
+                                    </Grid>
+                                </Border>
                                 <Grid Margin="0,16,0,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>


### PR DESCRIPTION
## Summary
- add settings to persist the last opened document and resume position
- expose a toggle in the Document Reader panel to control remembering progress
- persist document state while reading and restore the saved document on startup

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e18a22f1a0832d81ce4e1ec307da58