### PR TITLE
Add timers to dismiss status notifications and improve accessibility

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -997,7 +997,8 @@
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"
                            AutomationProperties.LiveSetting="Assertive"
-                           AutomationProperties.Name="{Binding StatusMessage}">
+                           AutomationProperties.Name="{Binding StatusAnnouncementAccessibilityText}"
+                           AutomationProperties.HelpText="{Binding StatusAnnouncementAccessibilityText}">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Foreground" Value="{DynamicResource StatusInfoForegroundBrush}"/>


### PR DESCRIPTION
## Summary
- add dispatcher-based timers so status notifications dismiss automatically after severity-specific delays
- expose accessible status announcement text and surface it through automation properties for assistive technologies

## Testing
- dotnet test *(fails: `dotnet` is not available in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e18e6bde1c832db3f84ea3434501cd