### PR TITLE
Improve document resume state persistence

### DIFF
--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -36,7 +36,7 @@ namespace Dissonance
 
                 public int DocumentReaderLastCharacterIndex { get; set; }
 
-                public DocumentReaderResumeState? DocumentReaderResumeState { get; set; }
+                public DocumentReaderResumeSnapshot? DocumentReaderResumeState { get; set; }
 
                 public class HotkeySettings
                 {
@@ -56,7 +56,7 @@ namespace Dissonance
                         public bool UsePlayPauseToggle { get; set; }
                 }
 
-                public class DocumentReaderResumeState
+                public class DocumentReaderResumeSnapshot
                 {
                         public string? FilePath { get; set; }
 

--- a/Dissonance/Dissonance/AppSettings.cs
+++ b/Dissonance/Dissonance/AppSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Dissonance
 {
         public class AppSettings
@@ -34,6 +36,8 @@ namespace Dissonance
 
                 public int DocumentReaderLastCharacterIndex { get; set; }
 
+                public DocumentReaderResumeState? DocumentReaderResumeState { get; set; }
+
                 public class HotkeySettings
                 {
                         public string Key { get; set; }
@@ -50,6 +54,21 @@ namespace Dissonance
                         public string Modifiers { get; set; }
 
                         public bool UsePlayPauseToggle { get; set; }
+                }
+
+                public class DocumentReaderResumeState
+                {
+                        public string? FilePath { get; set; }
+
+                        public int CharacterIndex { get; set; }
+
+                        public int DocumentLength { get; set; }
+
+                        public string? ContentHash { get; set; }
+
+                        public long? FileSize { get; set; }
+
+                        public DateTime? LastWriteTimeUtc { get; set; }
                 }
         }
 }

--- a/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
+++ b/Dissonance/Dissonance/Services/SettingsService/SettingsService.cs
@@ -276,12 +276,12 @@ namespace Dissonance.Services.SettingsService
                         return fallback;
                 }
 
-                private static AppSettings.DocumentReaderResumeState? CloneResumeState ( AppSettings.DocumentReaderResumeState? state )
+                private static AppSettings.DocumentReaderResumeSnapshot? CloneResumeState ( AppSettings.DocumentReaderResumeSnapshot? state )
                 {
                         if ( state == null )
                                 return null;
 
-                        return new AppSettings.DocumentReaderResumeState
+                        return new AppSettings.DocumentReaderResumeSnapshot
                         {
                                 FilePath = state.FilePath,
                                 CharacterIndex = state.CharacterIndex,
@@ -292,7 +292,7 @@ namespace Dissonance.Services.SettingsService
                         };
                 }
 
-                private static AppSettings.DocumentReaderResumeState? NormalizeResumeState ( AppSettings settings, AppSettings fallback )
+                private static AppSettings.DocumentReaderResumeSnapshot? NormalizeResumeState ( AppSettings settings, AppSettings fallback )
                 {
                         var normalizedFromState = NormalizeResumeState ( settings.DocumentReaderResumeState );
                         if ( normalizedFromState != null )
@@ -300,7 +300,7 @@ namespace Dissonance.Services.SettingsService
 
                         if ( !string.IsNullOrWhiteSpace ( settings.DocumentReaderLastFilePath ) )
                         {
-                                return new AppSettings.DocumentReaderResumeState
+                                return new AppSettings.DocumentReaderResumeSnapshot
                                 {
                                         FilePath = settings.DocumentReaderLastFilePath,
                                         CharacterIndex = Math.Max ( 0, settings.DocumentReaderLastCharacterIndex ),
@@ -314,7 +314,7 @@ namespace Dissonance.Services.SettingsService
                         return CloneResumeState ( fallback.DocumentReaderResumeState );
                 }
 
-                private static AppSettings.DocumentReaderResumeState? NormalizeResumeState ( AppSettings.DocumentReaderResumeState? state )
+                private static AppSettings.DocumentReaderResumeSnapshot? NormalizeResumeState ( AppSettings.DocumentReaderResumeSnapshot? state )
                 {
                         if ( state == null )
                                 return null;
@@ -322,7 +322,7 @@ namespace Dissonance.Services.SettingsService
                         if ( string.IsNullOrWhiteSpace ( state.FilePath ) )
                                 return null;
 
-                        return new AppSettings.DocumentReaderResumeState
+                        return new AppSettings.DocumentReaderResumeSnapshot
                         {
                                 FilePath = state.FilePath,
                                 CharacterIndex = Math.Max ( 0, state.CharacterIndex ),

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -1033,7 +1033,7 @@ namespace Dissonance.ViewModels
                         var resumeState = settings.DocumentReaderResumeState;
                         if (resumeState == null && !string.IsNullOrWhiteSpace(settings.DocumentReaderLastFilePath))
                         {
-                                resumeState = new AppSettings.DocumentReaderResumeState
+                                resumeState = new AppSettings.DocumentReaderResumeSnapshot
                                 {
                                         FilePath = settings.DocumentReaderLastFilePath,
                                         CharacterIndex = Math.Max(0, settings.DocumentReaderLastCharacterIndex),
@@ -1085,7 +1085,7 @@ namespace Dissonance.ViewModels
                                 }
                         }
 
-                        var state = new AppSettings.DocumentReaderResumeState
+                        var state = new AppSettings.DocumentReaderResumeSnapshot
                         {
                                 FilePath = metadata.FilePath,
                                 CharacterIndex = normalizedIndex,
@@ -1135,7 +1135,7 @@ namespace Dissonance.ViewModels
                         _settingsService.SaveCurrentSettings();
                 }
 
-                private async void RestoreDocumentFromSettings(AppSettings.DocumentReaderResumeState resumeState)
+                private async void RestoreDocumentFromSettings(AppSettings.DocumentReaderResumeSnapshot resumeState)
                 {
                         try
                         {
@@ -1284,7 +1284,7 @@ namespace Dissonance.ViewModels
                         return Math.Abs((first.Value - second.Value).TotalSeconds) <= 1;
                 }
 
-                private static bool IsMetadataCompatible(AppSettings.DocumentReaderResumeState expected, DocumentMetadata actual)
+                private static bool IsMetadataCompatible(AppSettings.DocumentReaderResumeSnapshot expected, DocumentMetadata actual)
                 {
                         if (expected == null)
                                 return false;


### PR DESCRIPTION
## Summary
- add a structured resume state to app settings so document progress includes hashes and file metadata
- teach the settings service to normalize, clone, and persist the new resume state alongside legacy fields
- overhaul the document reader view model to track document metadata, validate saved progress, and guard persistence logic while loading or resetting

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e192439fcc832db6d7819cf16619c2