### PR TITLE
Disable automatic CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+  # Temporarily disable automatic CI/CD triggers while keeping this workflow
+  # available for manual runs. Retain the previous configuration for future
+  # reference by commenting it out below.
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- disable the CI workflow's automatic push and pull_request triggers while retaining the file for future manual use

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e193409610832db99ffbec543b6be1