### PR TITLE
Correct documentation asset links and feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# Dissonance---Accessibility-Tool
-A general purpose accessibility tool for visually impaired users.
+# Dissonance Accessibility Tool
+
+Dissonance is a Windows desktop application that empowers visually impaired users to interact with rich on-screen content. It combines real-time screen capture with accessible presentation layers so that critical information can be reviewed or read aloud.
+
+![Home page – light mode](./Dissonance/Dissonance/Assets/Wiki/home_page_light_mode.png)
+
+## Key Features
+
+- **Clipboard Reader** – Automatically ingests copied text and presents it in a customizable reading pane with text-to-speech integration.
+- **Session History** – Preserves previously captured snippets, making it easy to revisit important information.
+- **Text-to-Speech Controls** – Works with installed Windows voices and provides rate and volume adjustments.
+- **Theming** – Light and dark themes ensure comfortable viewing in a range of environments.
+- **Extensible Architecture** – Service- and manager-based abstractions make it straightforward to add new capture or export pipelines.
+
+![Clipboard Reader – dark mode](./Dissonance/Dissonance/Assets/Wiki/clipboard_reader_page_dark_mode.png)
+
+## Getting Started
+
+### Prerequisites
+
+- Windows 10 or later
+- .NET Desktop Runtime 8.0 (for running) or .NET SDK 8.0 (for development)
+
+### Installation
+
+1. Clone the repository.
+2. Restore the solution dependencies: `dotnet restore`.
+3. Build the application: `dotnet build Dissonance.sln`.
+4. Launch the app from the generated binaries in `Dissonance/bin/`.
+
+## Usage Overview
+
+1. Launch Dissonance.
+2. Copy any text from another application.
+3. Switch to the Clipboard Reader view to review, edit, or listen to the captured content.
+4. Use the toolbar to toggle themes or access additional utilities.
+
+## Architecture Highlights
+
+- **Services** encapsulate integrations such as speech synthesis and clipboard monitoring.
+- **Managers** coordinate domain logic like session history and UI state transitions.
+- **ViewModels** implement MVVM bindings for the WPF views, ensuring testability and separation of concerns.
+
+## Accessibility Considerations
+
+- Provides full text-to-speech playback with configurable voice, rate, and volume.
+- Offers light and dark themes to accommodate different contrast needs.
+- Includes keyboard shortcuts and hotkeys so core actions remain accessible without a mouse.
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Run the test suite with `dotnet test`.
+3. Submit a pull request with a detailed description of your changes.
+
+## License
+
+This project is released under the MIT License. See the [`LICENSE`](LICENSE) file for details.
+
+## Additional Resources
+
+For more detailed walkthroughs and design notes, see the [project wiki](./wiki/Home.md).

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,37 @@
+# Architecture Overview
+
+This document summarizes the major projects, layers, and patterns that power Dissonance.
+
+## Solution Layout
+
+- **Dissonance** – WPF application project that contains the UI, view models, services, and managers.
+- **Dissonance.Tests** – Test project focused on validating service and manager logic.
+
+## Core Layers
+
+| Layer | Description |
+| --- | --- |
+| UI (Views) | XAML views located in `Windows/` and `Resources/` deliver the interface. |
+| ViewModels | `ViewModels/` contains MVVM bindings used by the views. |
+| Services | `Services/` wraps platform integrations such as speech synthesis and clipboard access. |
+| Managers | `Managers/` orchestrate higher-level workflows, including session history and configuration. |
+| Infrastructure | `Infrastructure/` houses shared helpers such as dependency injection and configuration. |
+
+## Data Flow
+
+1. A clipboard update is detected by the `ClipboardService`.
+2. The `HistoryManager` persists the new entry and notifies subscribers.
+3. The corresponding view model updates observable properties.
+4. The view reflects the change through data binding.
+
+## Extending the Application
+
+- Add new services to `Services/` and register them in the dependency injection container.
+- Create or modify view models to expose new functionality.
+- Update XAML views to present new interactions or data visualizations.
+
+## Testing Strategy
+
+- Unit tests live in `Dissonance.Tests` and target services and managers.
+- Use mocking frameworks to simulate clipboard and speech synthesis behavior.
+- Automate UI smoke tests with tools such as WinAppDriver for regression coverage.

--- a/wiki/Clipboard-Reader.md
+++ b/wiki/Clipboard-Reader.md
@@ -1,0 +1,31 @@
+# Clipboard Reader
+
+The Clipboard Reader is the heart of Dissonance. It continuously monitors the system clipboard and surfaces content in an accessible format.
+
+![Clipboard Reader – dark mode](../Dissonance/Dissonance/Assets/Wiki/clipboard_reader_page_dark_mode.png)
+
+## Workflow
+
+1. Copy text in any Windows application.
+2. Dissonance captures the clipboard contents and adds it to the session history.
+3. The Clipboard Reader view displays the captured text alongside speech playback controls and entry metadata.
+
+## Key Components
+
+- **ClipboardService** – Listens for clipboard updates and publishes new entries.
+- **HistoryManager** – Stores clipboard snapshots and provides filtering and retrieval utilities.
+- **ClipboardReaderViewModel** – Bridges the UI and services, exposing properties for the WPF views.
+
+## Tips for Power Users
+
+- Use keyboard shortcuts to navigate between history items without leaving the reader view.
+- Play, pause, or stop narration directly from the reader toolbar.
+- Adjust the voice, rate, and volume to match the context you are working in.
+
+## Troubleshooting
+
+If clipboard monitoring stops working:
+
+- Confirm no other application has locked the clipboard.
+- Restart Dissonance to re-initialize the listener hooks.
+- Check the application logs for exceptions or warnings.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+This guide covers the basics of cloning, building, and running Dissonance on a Windows development machine.
+
+![Clipboard Reader – light mode](../Dissonance/Dissonance/Assets/Wiki/clipboard_reader_page_light_mode.png)
+
+## Prerequisites
+
+- Windows 10 or newer
+- .NET SDK 8.0 (includes the necessary desktop workloads)
+- Git
+
+## Clone the Repository
+
+```powershell
+git clone https://github.com/<your-account>/Dissonance.git
+cd Dissonance
+```
+
+## Restore and Build
+
+```powershell
+dotnet restore Dissonance.sln
+dotnet build Dissonance.sln
+```
+
+The build output is located in `Dissonance/bin/<Configuration>/<TargetFramework>/`.
+
+## Run the Application
+
+```powershell
+dotnet run --project Dissonance/Dissonance.csproj
+```
+
+Running with `dotnet run` launches the WPF app using the current build configuration.
+
+## Run Tests
+
+```powershell
+dotnet test
+```
+
+The solution includes unit tests in the `Dissonance.Tests` project. Make sure the suite passes before submitting a pull request.
+
+## Next Steps
+
+- Review the [Architecture Overview](./Architecture.md) for a deep dive into the solution structure.
+- Explore the [Theming](./Theming.md) guide to learn how to customize the UI experience.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,20 @@
+# Dissonance Wiki
+
+Welcome to the Dissonance project wiki. This space gathers guides and reference material for contributors and power users.
+
+![Home page – dark mode](../Dissonance/Dissonance/Assets/Wiki/home_page_dark_mode.png)
+
+## Contents
+
+- [Getting Started](./Getting-Started.md)
+- [Clipboard Reader](./Clipboard-Reader.md)
+- [Theming](./Theming.md)
+- [Architecture Overview](./Architecture.md)
+
+## Project Vision
+
+Dissonance bridges the gap between traditional desktop workflows and accessible user experiences. The application listens for clipboard activity, curates captured content, and exposes it through a highly accessible interface. Our goals are to:
+
+- Provide a reliable companion tool for screen reader users.
+- Support efficient review of copied content with history tracking and text-to-speech playback.
+- Encourage community contributions that expand assistive capabilities.

--- a/wiki/Theming.md
+++ b/wiki/Theming.md
@@ -1,0 +1,21 @@
+# Theming
+
+Dissonance ships with light and dark themes so users can pick the most comfortable contrast profile.
+
+![Home page – light mode](../Dissonance/Dissonance/Assets/Wiki/home_page_light_mode.png)
+
+## Switching Themes
+
+- Use the theme toggle in the application toolbar to switch between light and dark modes.
+- The setting persists between sessions and is stored in the user configuration file.
+
+## Customizing Colors
+
+Developers can introduce new color resources in `Resources/Styles.xaml`. The MVVM bindings reference these resources, so changes automatically propagate through the UI.
+
+## Accessibility Tips
+
+- Choose high-contrast color combinations that meet WCAG AA or AAA guidelines.
+- Test theme changes with screen readers to ensure focus indicators remain clear.
+
+![Home page – dark mode](../Dissonance/Dissonance/Assets/Wiki/home_page_dark_mode.png)


### PR DESCRIPTION
## Summary
- replace the minimal README with a detailed overview that highlights features, setup steps, and accessibility considerations, including project screenshots
- add a documentation wiki with guides for getting started, using the clipboard reader, theming, and understanding the architecture
- correct documentation image links and align feature descriptions with functionality that exists in the application

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e193540bd4832d97f9e76f658e8a47