### PR TITLE
Ensure hotkey text boxes support keyboard navigation

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -236,6 +236,7 @@
                                                  Text="{Binding PlaybackHotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  IsReadOnly="True"
                                                  TabIndex="3"
+                                                 Tag="{Binding ElementName=DocumentPlaybackHotkeyApplyButton}"
                                                  ToolTip="Press the keys you want to use for the document playback hotkey"
                                                  PreviewKeyDown="DocumentPlaybackHotkeyTextBox_PreviewKeyDown"
                                                  AutomationProperties.LabeledBy="{Binding ElementName=PlaybackHotkeyHeading}"
@@ -587,6 +588,7 @@
                                          ToolTip="Set the hotkey used to copy the current selection and speak it aloud"
                                          TabIndex="0"
                                          IsReadOnly="True"
+                                         Tag="{Binding ElementName=ReadClipboardHotkeyApplyButton}"
                                          PreviewKeyDown="ReadClipboardHotkeyTextBox_PreviewKeyDown"
                                          AutomationProperties.HelpText="Specify the key combination that copies the current selection and speaks it aloud"/>
                                 <Button x:Name="ReadClipboardHotkeyApplyButton"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -331,7 +331,7 @@ namespace Dissonance
 
                         var key = e.Key == Key.System ? e.SystemKey : e.Key;
 
-                        if ( TryHandleHotkeyTabNavigation ( control, key, e, ReadClipboardHotkeyApplyButton ) )
+                        if ( TryHandleHotkeyTabNavigation ( control, key, e ) )
                         {
                                 return;
                         }
@@ -364,7 +364,7 @@ namespace Dissonance
 
                         var key = e.Key == Key.System ? e.SystemKey : e.Key;
 
-                        if ( TryHandleHotkeyTabNavigation ( textBox, key, e, DocumentPlaybackHotkeyApplyButton ) )
+                        if ( TryHandleHotkeyTabNavigation ( textBox, key, e ) )
                                 return;
 
                         if ( key == Key.Back || key == Key.Delete || key == Key.Escape )
@@ -467,7 +467,7 @@ namespace Dissonance
                         return modifiers;
                 }
 
-                private static bool TryHandleHotkeyTabNavigation ( Control control, Key key, KeyEventArgs e, IInputElement? nextElement )
+                private static bool TryHandleHotkeyTabNavigation ( Control control, Key key, KeyEventArgs e )
                 {
                         if ( key != Key.Tab )
                         {
@@ -487,7 +487,11 @@ namespace Dissonance
                                 return movedToPrevious;
                         }
 
-                        if ( nextElement is UIElement element && element.IsEnabled && element.IsVisible )
+                        if ( control is FrameworkElement frameworkElement
+                                && frameworkElement.Tag is IInputElement nextElement
+                                && nextElement is UIElement element
+                                && element.IsEnabled
+                                && element.IsVisible )
                         {
                                 var focused = element.Focus ( );
 


### PR DESCRIPTION
## Summary
- allow the clipboard and playback hotkey text boxes to hand off Tab presses to focus navigation
- centralize the Tab handling logic so all hotkey inputs share consistent accessibility behavior

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec5953f8832dac536a0d77c3767f