### PR TITLE
Refine document reader layout

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -86,115 +86,77 @@
                             Margin="0,0,0,20">
                     <TextBlock Text="Open a text document to review it before narration."
                                Style="{StaticResource CardDescriptionTextStyle}"/>
-                    <StackPanel Orientation="Horizontal"
-                                Margin="0,12,0,0"
-                                HorizontalAlignment="Left">
-                        <Button Content="Open document…"
-                                Command="{Binding BrowseForDocumentCommand}"
-                                Style="{StaticResource PrimaryCompactButtonStyle}"
-                                MinWidth="160"
-                                MinHeight="32"
-                                TabIndex="0"
-                                ToolTip="Browse for a text document to preview before narration"
-                                AutomationProperties.Name="Open document"
-                                AutomationProperties.HelpText="Opens a file picker so you can choose a text document to load"/>
-                        <Button Content="Clear"
-                                Command="{Binding ClearDocumentCommand}"
-                                Style="{StaticResource PrimaryCompactButtonStyle}"
-                                MinWidth="120"
-                                MinHeight="32"
-                                Margin="12,0,0,0"
-                                TabIndex="1"
-                                ToolTip="Remove the currently loaded document"
-                                AutomationProperties.Name="Clear loaded document"
-                                AutomationProperties.HelpText="Unloads the current document and resets the preview"/>
-                    </StackPanel>
-                    <ProgressBar Height="4"
-                                 Margin="0,16,0,0"
-                                 IsIndeterminate="True">
-                        <ProgressBar.Style>
-                            <Style TargetType="ProgressBar">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ProgressBar.Style>
-                    </ProgressBar>
                 </StackPanel>
 
                 <Grid Grid.Row="1">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="320"/>
+                        <ColumnDefinition Width="400"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
                     <Border Grid.Column="0"
                             Style="{StaticResource CardContainerStyle}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-                            <StackPanel Grid.Row="0">
-                                <TextBlock Text="Document details"
-                                           Style="{StaticResource CardTitleTextStyle}"/>
-                                <TextBlock Text="Supported format: plain text (.txt)"
-                                           Style="{StaticResource CardDescriptionTextStyle}"
-                                           Margin="0,6,0,0"/>
-                                <TextBlock Text="Selected file"
-                                           FontWeight="SemiBold"
-                                           Margin="0,16,0,0"/>
-                                <TextBox Style="{StaticResource ModernTextBoxStyle}"
-                                         Text="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"
-                                         IsReadOnly="True"
-                                         Margin="0,8,0,0"
-                                         HorizontalAlignment="Stretch"
-                                         TextWrapping="Wrap"
-                                         MinHeight="34"
-                                         IsTabStop="False"
-                                         ToolTip="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"/>
-                                <Border Margin="0,16,0,0"
-                                        Padding="12"
-                                        Background="{DynamicResource SurfaceBackgroundBrush}"
-                                        BorderBrush="{DynamicResource CardBorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="8">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel Grid.Column="0"
-                                                    Orientation="Vertical"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Center"
-                                                    MaxWidth="240">
-                                            <TextBlock x:Name="RememberDocumentToggleLabel"
-                                                       Text="Remember document progress"
-                                                       FontSize="14"
-                                                       FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                                            <TextBlock Margin="0,4,0,0"
-                                                       Text="Reopen the last document and resume where you left off."
-                                                       Style="{StaticResource CardDescriptionTextStyle}"
-                                                       TextWrapping="Wrap"/>
-                                        </StackPanel>
-                                        <ToggleButton Grid.Column="1"
-                                                      Style="{StaticResource SettingsToggleSwitchStyle}"
-                                                      IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
-                                                      VerticalAlignment="Center"
-                                                      Margin="16,0,0,0"
-                                                      TabIndex="2"
-                                                      ToolTip="Remember your last document and reading position when Dissonance starts"
-                                                      AutomationProperties.Name="Remember the last document and position"
-                                                      AutomationProperties.HelpText="When enabled, Dissonance reopens the last document and restores the saved reading position."
-                                                      AutomationProperties.LabeledBy="{Binding ElementName=RememberDocumentToggleLabel}"/>
-                                    </Grid>
-                                </Border>
-                                <Grid Margin="0,16,0,0">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <StackPanel>
+                                    <TextBlock Text="Document details"
+                                               Style="{StaticResource CardTitleTextStyle}"/>
+                                    <TextBlock Text="Supported format: plain text (.txt)"
+                                               Style="{StaticResource CardDescriptionTextStyle}"
+                                               Margin="0,6,0,0"/>
+                                    <TextBlock Text="Selected file"
+                                               FontWeight="SemiBold"
+                                               Margin="0,16,0,0"/>
+                                    <TextBox Style="{StaticResource ModernTextBoxStyle}"
+                                             Text="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"
+                                             IsReadOnly="True"
+                                             Margin="0,8,0,0"
+                                             HorizontalAlignment="Stretch"
+                                             TextWrapping="Wrap"
+                                             MinHeight="34"
+                                             IsTabStop="False"
+                                             ToolTip="{Binding FilePath, Mode=OneWay, TargetNullValue=No document selected}"/>
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="0,12,0,0"
+                                                HorizontalAlignment="Left">
+                                        <Button Content="Open document…"
+                                                Command="{Binding BrowseForDocumentCommand}"
+                                                Style="{StaticResource PrimaryCompactButtonStyle}"
+                                                MinWidth="160"
+                                                MinHeight="32"
+                                                TabIndex="0"
+                                                ToolTip="Browse for a text document to preview before narration"
+                                                AutomationProperties.Name="Open document"
+                                                AutomationProperties.HelpText="Opens a file picker so you can choose a text document to load"/>
+                                        <Button Content="Clear"
+                                                Command="{Binding ClearDocumentCommand}"
+                                                Style="{StaticResource PrimaryCompactButtonStyle}"
+                                                MinWidth="120"
+                                                MinHeight="32"
+                                                Margin="12,0,0,0"
+                                                TabIndex="1"
+                                                ToolTip="Remove the currently loaded document"
+                                                AutomationProperties.Name="Clear loaded document"
+                                                AutomationProperties.HelpText="Unloads the current document and resets the preview"/>
+                                    </StackPanel>
+                                    <ProgressBar Height="4"
+                                                 Margin="0,16,0,0"
+                                                 IsIndeterminate="True">
+                                        <ProgressBar.Style>
+                                            <Style TargetType="ProgressBar">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ProgressBar.Style>
+                                    </ProgressBar>
+                                </StackPanel>
+
+                                <Grid Margin="0,24,0,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="*"/>
@@ -230,12 +192,47 @@
                                                HorizontalAlignment="Center"
                                                TextAlignment="Center"/>
                                 </Grid>
-                            </StackPanel>
-                            <ScrollViewer Grid.Row="1"
-                                          Margin="0,24,0,0"
-                                          VerticalScrollBarVisibility="Auto"
-                                          HorizontalScrollBarVisibility="Disabled">
-                                <StackPanel>
+
+                                <Border Margin="0,24,0,0"
+                                        Padding="12"
+                                        Background="{DynamicResource SurfaceBackgroundBrush}"
+                                        BorderBrush="{DynamicResource CardBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0"
+                                                    Orientation="Vertical"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    MaxWidth="260">
+                                            <TextBlock x:Name="RememberDocumentToggleLabel"
+                                                       Text="Remember document progress"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                            <TextBlock Margin="0,4,0,0"
+                                                       Text="Reopen the last document and resume where you left off."
+                                                       Style="{StaticResource CardDescriptionTextStyle}"
+                                                       TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <ToggleButton Grid.Column="1"
+                                                      Style="{StaticResource SettingsToggleSwitchStyle}"
+                                                      IsChecked="{Binding RememberDocumentProgress, Mode=TwoWay}"
+                                                      VerticalAlignment="Center"
+                                                      Margin="16,0,0,0"
+                                                      TabIndex="2"
+                                                      ToolTip="Remember your last document and reading position when Dissonance starts"
+                                                      AutomationProperties.Name="Remember the last document and position"
+                                                      AutomationProperties.HelpText="When enabled, Dissonance reopens the last document and restores the saved reading position."
+                                                      AutomationProperties.LabeledBy="{Binding ElementName=RememberDocumentToggleLabel}"/>
+                                    </Grid>
+                                </Border>
+
+                                <StackPanel Margin="0,24,0,0">
                                     <TextBlock x:Name="PlaybackHotkeyHeading"
                                                Text="Playback hotkey"
                                                FontWeight="SemiBold"
@@ -247,7 +244,7 @@
                                     <StackPanel Orientation="Horizontal"
                                                 Margin="0,8,0,0">
                                         <TextBox x:Name="DocumentPlaybackHotkeyTextBox"
-                                                 Width="180"
+                                                 Width="200"
                                                  Style="{StaticResource ModernTextBoxStyle}"
                                                  Text="{Binding PlaybackHotkeyCombination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  IsReadOnly="True"
@@ -275,42 +272,40 @@
                                               TabIndex="5"
                                               AutomationProperties.Name="Toggle playback hotkey pause behavior"
                                               AutomationProperties.HelpText="Enable to make the playback hotkey pause and resume the document preview"/>
-                                    <StackPanel Orientation="Horizontal"
-                                                Margin="0,16,0,0"
-                                                VerticalAlignment="Center">
-                                        <TextBlock Text="Highlight color"
-                                                   Margin="0,0,12,0"
-                                                   VerticalAlignment="Center"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                                        <ComboBox ItemsSource="{Binding HighlightColorOptions}"
-                                                  SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
-                                                  DisplayMemberPath="DisplayName"
-                                                  MinWidth="200"
-                                                  Style="{StaticResource HighlightColorComboBoxStyle}"
-                                                  TabIndex="6"
-                                                  ToolTip="Choose the color used to highlight narration words"
-                                                  AutomationProperties.Name="Document highlight color"
-                                                  AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
-                                    </StackPanel>
-                                    <TextBlock Text="{Binding StatusMessage}"
-                                               Margin="0,20,0,0"
-                                               TextWrapping="Wrap"
-                                               Foreground="{DynamicResource AccentBrush}">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
                                 </StackPanel>
-                            </ScrollViewer>
-                        </Grid>
+
+                                <StackPanel Margin="0,24,0,0">
+                                    <TextBlock Text="Highlight color"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                                    <ComboBox ItemsSource="{Binding HighlightColorOptions}"
+                                              SelectedItem="{Binding SelectedHighlightColor, Mode=TwoWay}"
+                                              DisplayMemberPath="DisplayName"
+                                              Margin="0,8,0,0"
+                                              Style="{StaticResource HighlightColorComboBoxStyle}"
+                                              TabIndex="6"
+                                              ToolTip="Choose the color used to highlight narration words"
+                                              AutomationProperties.Name="Document highlight color"
+                                              AutomationProperties.HelpText="Select the color used to highlight the words being narrated"/>
+                                </StackPanel>
+
+                                <TextBlock Text="{Binding StatusMessage}"
+                                           Margin="0,24,0,0"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource AccentBrush}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </StackPanel>
+                        </ScrollViewer>
                     </Border>
 
                     <Border Grid.Column="1"
@@ -409,6 +404,7 @@
                 </Grid>
             </Grid>
         </DataTemplate>
+
         <DataTemplate DataType="{x:Type local:ReaderSettingsViewModel}">
             <Grid>
                 <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- enlarge the document reader side panel and move the document actions inside the card for a clearer flow
- regroup the progress indicator, document stats, playback hotkey, and highlight options in a scrollable stack so controls are no longer squished

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3ece1a4b8832d8cd737b67e543f5e