### PR TITLE
Add EPUB support to document reader

### DIFF
--- a/Dissonance/Dissonance.Tests/Services/DocumentReaderServiceTests.cs
+++ b/Dissonance/Dissonance.Tests/Services/DocumentReaderServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Text;
 using System.Threading.Tasks;
 
 using Dissonance.Services.DocumentReader;
@@ -37,6 +39,31 @@ namespace Dissonance.Tests.Services
                 }
 
                 [Fact]
+                public async Task ReadDocumentAsync_WithValidEpubFile_ReturnsExtractedContent()
+                {
+                        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".epub");
+
+                        try
+                        {
+                                await CreateSampleEpubAsync(tempFile);
+
+                                var service = new DocumentReaderService();
+                                var result = await service.ReadDocumentAsync(tempFile);
+
+                                Assert.Equal(tempFile, result.FilePath);
+                                Assert.Equal("Sample Heading\nThis is the first paragraph.\nSecond paragraph.", result.PlainText);
+                                Assert.Equal(9, result.WordCount);
+                        }
+                        finally
+                        {
+                                if (File.Exists(tempFile))
+                                {
+                                        File.Delete(tempFile);
+                                }
+                        }
+                }
+
+                [Fact]
                 public async Task ReadDocumentAsync_WithMissingFile_Throws()
                 {
                         var service = new DocumentReaderService();
@@ -59,6 +86,49 @@ namespace Dissonance.Tests.Services
                                 if (File.Exists(tempFile))
                                 {
                                         File.Delete(tempFile);
+                                }
+                        }
+                }
+
+                private static async Task CreateSampleEpubAsync(string filePath)
+                {
+                        await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                        using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: Encoding.UTF8))
+                        {
+                                var containerEntry = archive.CreateEntry("META-INF/container.xml");
+                                await using (var containerStream = containerEntry.Open())
+                                await using (var writer = new StreamWriter(containerStream, Encoding.UTF8))
+                                {
+                                        await writer.WriteAsync("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                                                "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                                                "</container>");
+                                }
+
+                                var packageEntry = archive.CreateEntry("OEBPS/content.opf");
+                                await using (var packageStream = packageEntry.Open())
+                                await using (var writer = new StreamWriter(packageStream, Encoding.UTF8))
+                                {
+                                        await writer.WriteAsync("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                                "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+                                                "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:title>Sample</dc:title></metadata>" +
+                                                "<manifest>" +
+                                                "<item id=\"chap1\" href=\"text/chapter1.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                                                "</manifest>" +
+                                                "<spine><itemref idref=\"chap1\"/></spine>" +
+                                                "</package>");
+                                }
+
+                                var chapterEntry = archive.CreateEntry("OEBPS/text/chapter1.xhtml");
+                                await using (var chapterStream = chapterEntry.Open())
+                                await using (var writer = new StreamWriter(chapterStream, Encoding.UTF8))
+                                {
+                                        await writer.WriteAsync("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Sample</title></head><body>" +
+                                                "<h1>Sample Heading</h1>" +
+                                                "<p>This is the first paragraph.</p>" +
+                                                "<p>Second paragraph.</p>" +
+                                                "</body></html>");
                                 }
                         }
                 }

--- a/Dissonance/Dissonance/Services/DocumentReader/DocumentReaderService.cs
+++ b/Dissonance/Dissonance/Services/DocumentReader/DocumentReaderService.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Dissonance.Services.DocumentReader
 {
@@ -17,21 +22,375 @@ namespace Dissonance.Services.DocumentReader
                                 throw new FileNotFoundException("The specified document could not be found.", filePath);
 
                         var extension = Path.GetExtension(filePath);
-                        if (!string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase))
-                                throw new NotSupportedException($"The document type '{extension}' is not supported.");
-
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        string content;
-                        using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                        using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+                        string content = extension.ToLowerInvariant() switch
                         {
-                                content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                        }
+                                ".txt" => await ReadTextFileAsync(filePath, cancellationToken).ConfigureAwait(false),
+                                ".epub" => await ReadEpubFileAsync(filePath, cancellationToken).ConfigureAwait(false),
+                                _ => throw new NotSupportedException($"The document type '{extension}' is not supported."),
+                        };
 
                         cancellationToken.ThrowIfCancellationRequested();
 
                         return new DocumentReadResult(filePath, content ?? string.Empty);
+                }
+
+                private static async Task<string> ReadTextFileAsync(string filePath, CancellationToken cancellationToken)
+                {
+                        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+                        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return content ?? string.Empty;
+                }
+
+                private static async Task<string> ReadEpubFileAsync(string filePath, CancellationToken cancellationToken)
+                {
+                        using var archive = ZipFile.OpenRead(filePath);
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var containerEntry = archive.GetEntry("META-INF/container.xml")
+                                ?? throw new InvalidDataException("The EPUB file is missing its container manifest.");
+
+                        var containerDocument = await LoadXmlAsync(containerEntry, cancellationToken).ConfigureAwait(false);
+                        var rootFilePath = containerDocument
+                                .Descendants()
+                                .FirstOrDefault(e => e.Name.LocalName.Equals("rootfile", StringComparison.OrdinalIgnoreCase))
+                                ?.Attribute("full-path")?.Value;
+
+                        if (string.IsNullOrWhiteSpace(rootFilePath))
+                                throw new InvalidDataException("The EPUB file does not specify a package document.");
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        rootFilePath = NormalizeEntryPath(rootFilePath);
+                        var packageEntry = archive.GetEntry(rootFilePath)
+                                ?? throw new InvalidDataException("The EPUB file references a missing package document.");
+
+                        var packageDocument = await LoadXmlAsync(packageEntry, cancellationToken).ConfigureAwait(false);
+
+                        var manifestItems = packageDocument
+                                .Descendants()
+                                .Where(e => e.Name.LocalName.Equals("item", StringComparison.OrdinalIgnoreCase))
+                                .Select(e => new ManifestItem(
+                                        e.Attribute("id")?.Value ?? string.Empty,
+                                        NormalizeHref(e.Attribute("href")?.Value ?? string.Empty),
+                                        e.Attribute("media-type")?.Value))
+                                .Where(item => !string.IsNullOrEmpty(item.Id) && !string.IsNullOrEmpty(item.Href))
+                                .ToDictionary(item => item.Id, StringComparer.OrdinalIgnoreCase);
+
+                        if (manifestItems.Count == 0)
+                                throw new InvalidDataException("The EPUB file does not contain any manifest items.");
+
+                        var spineOrder = packageDocument
+                                .Descendants()
+                                .Where(e => e.Name.LocalName.Equals("itemref", StringComparison.OrdinalIgnoreCase))
+                                .Select(e => e.Attribute("idref")?.Value)
+                                .Where(id => !string.IsNullOrEmpty(id))
+                                .ToList();
+
+                        var contentItems = new List<ManifestItem>();
+                        foreach (var id in spineOrder)
+                        {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                if (id != null && manifestItems.TryGetValue(id, out var item) && IsReadableMediaType(item.MediaType))
+                                {
+                                        contentItems.Add(item);
+                                }
+                        }
+
+                        if (contentItems.Count == 0)
+                        {
+                                contentItems.AddRange(manifestItems.Values.Where(item => IsReadableMediaType(item.MediaType)));
+                        }
+
+                        if (contentItems.Count == 0)
+                                throw new InvalidDataException("The EPUB file does not contain any readable content.");
+
+                        var basePath = GetBasePath(rootFilePath);
+                        var builder = new StringBuilder();
+
+                        foreach (var item in contentItems)
+                        {
+                                cancellationToken.ThrowIfCancellationRequested();
+
+                                var entryPath = CombineEntryPath(basePath, item.Href);
+                                var entry = archive.GetEntry(entryPath);
+                                if (entry == null)
+                                        continue;
+
+                                var mediaType = item.MediaType?.ToLowerInvariant();
+                                if (string.Equals(mediaType, "text/plain", StringComparison.Ordinal))
+                                {
+                                        var text = await ReadZipEntryTextAsync(entry).ConfigureAwait(false);
+                                        AppendContent(builder, text);
+                                        continue;
+                                }
+
+                                var xhtmlDocument = await LoadXmlAsync(entry, cancellationToken, isHtml: true).ConfigureAwait(false);
+                                var textContent = ExtractPlainText(xhtmlDocument.Root);
+                                AppendContent(builder, textContent);
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        return NormalizePlainText(builder.ToString());
+                }
+
+                private static async Task<XDocument> LoadXmlAsync(ZipArchiveEntry entry, CancellationToken cancellationToken, bool isHtml = false)
+                {
+                        using var stream = entry.Open();
+                        var settings = new XmlReaderSettings
+                        {
+                                Async = true,
+                                DtdProcessing = DtdProcessing.Ignore,
+                                IgnoreComments = true,
+                                IgnoreProcessingInstructions = true,
+                                IgnoreWhitespace = isHtml,
+                        };
+
+                        using var reader = XmlReader.Create(stream, settings);
+                        return await XDocument.LoadAsync(reader, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+                }
+
+                private static async Task<string> ReadZipEntryTextAsync(ZipArchiveEntry entry)
+                {
+                        using var stream = entry.Open();
+                        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+                        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        return content ?? string.Empty;
+                }
+
+                private static void AppendContent(StringBuilder builder, string content)
+                {
+                        if (string.IsNullOrWhiteSpace(content))
+                                return;
+
+                        if (builder.Length > 0)
+                                builder.AppendLine();
+
+                        builder.Append(content.Trim());
+                }
+
+                private static string ExtractPlainText(XElement? element)
+                {
+                        if (element == null)
+                                return string.Empty;
+
+                        var builder = new StringBuilder();
+                        AppendNodeText(element, builder);
+                        return builder.ToString();
+                }
+
+                private static void AppendNodeText(XNode node, StringBuilder builder)
+                {
+                        switch (node)
+                        {
+                                case XText textNode:
+                                        var value = textNode.Value;
+                                        if (!string.IsNullOrWhiteSpace(value))
+                                        {
+                                                builder.Append(value);
+                                        }
+                                        else
+                                        {
+                                                builder.Append(' ');
+                                        }
+
+                                        break;
+
+                                case XElement elementNode:
+                                        if (ShouldSkipElement(elementNode.Name.LocalName))
+                                                return;
+
+                                        if (string.Equals(elementNode.Name.LocalName, "br", StringComparison.OrdinalIgnoreCase))
+                                                builder.Append('\n');
+
+                                        foreach (var child in elementNode.Nodes())
+                                        {
+                                                AppendNodeText(child, builder);
+                                        }
+
+                                        if (IsBlockElement(elementNode.Name.LocalName))
+                                                builder.Append('\n');
+
+                                        break;
+                        }
+                }
+
+                private static bool ShouldSkipElement(string localName)
+                {
+                        return localName.Equals("script", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("style", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("svg", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("nav", StringComparison.OrdinalIgnoreCase);
+                }
+
+                private static bool IsBlockElement(string localName)
+                {
+                        return localName.Equals("p", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("div", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("section", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("article", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("header", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("footer", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("li", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("ul", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("ol", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h1", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h2", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h3", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h4", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h5", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("h6", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("tr", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("table", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("body", StringComparison.OrdinalIgnoreCase)
+                                || localName.Equals("html", StringComparison.OrdinalIgnoreCase);
+                }
+
+                private static string NormalizePlainText(string text)
+                {
+                        if (string.IsNullOrWhiteSpace(text))
+                                return string.Empty;
+
+                        var builder = new StringBuilder();
+                        var previousWasSpace = false;
+                        var previousWasNewline = false;
+
+                        foreach (var ch in text.Replace('\r', '\n'))
+                        {
+                                if (ch == '\n')
+                                {
+                                        if (!previousWasNewline && builder.Length > 0 && builder[builder.Length - 1] == ' ')
+                                        {
+                                                builder.Length -= 1;
+                                        }
+
+                                        if (!previousWasNewline)
+                                        {
+                                                builder.Append('\n');
+                                        }
+
+                                        previousWasNewline = true;
+                                        previousWasSpace = false;
+                                }
+                                else if (char.IsWhiteSpace(ch))
+                                {
+                                        if (!previousWasSpace && !previousWasNewline)
+                                        {
+                                                if (builder.Length > 0)
+                                                        builder.Append(' ');
+
+                                                previousWasSpace = true;
+                                        }
+                                }
+                                else
+                                {
+                                        builder.Append(ch);
+                                        previousWasSpace = false;
+                                        previousWasNewline = false;
+                                }
+                        }
+
+                        return builder.ToString().Trim();
+                }
+
+                private static bool IsReadableMediaType(string? mediaType)
+                {
+                        if (string.IsNullOrWhiteSpace(mediaType))
+                                return false;
+
+                        mediaType = mediaType.ToLowerInvariant();
+                        return mediaType.Contains("xhtml")
+                                || mediaType.Contains("html")
+                                || mediaType.Contains("text");
+                }
+
+                private static string NormalizeHref(string href)
+                {
+                        if (string.IsNullOrWhiteSpace(href))
+                                return string.Empty;
+
+                        href = href.Replace('\\', '/');
+                        try
+                        {
+                                href = Uri.UnescapeDataString(href);
+                        }
+                        catch
+                        {
+                                // Ignore malformed escape sequences and fall back to the raw value.
+                        }
+
+                        return NormalizeEntryPath(href);
+                }
+
+                private static string NormalizeEntryPath(string path)
+                {
+                        if (string.IsNullOrWhiteSpace(path))
+                                return string.Empty;
+
+                        var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                        var stack = new Stack<string>();
+
+                        foreach (var segment in segments)
+                        {
+                                if (segment == ".")
+                                        continue;
+
+                                if (segment == "..")
+                                {
+                                        if (stack.Count > 0)
+                                                stack.Pop();
+
+                                        continue;
+                                }
+
+                                stack.Push(segment);
+                        }
+
+                        return string.Join('/', stack.Reverse());
+                }
+
+                private static string CombineEntryPath(string basePath, string relativePath)
+                {
+                        if (string.IsNullOrEmpty(basePath))
+                                return NormalizeEntryPath(relativePath);
+
+                        if (string.IsNullOrEmpty(relativePath))
+                                return NormalizeEntryPath(basePath);
+
+                        return NormalizeEntryPath(basePath.TrimEnd('/') + "/" + relativePath);
+                }
+
+                private static string GetBasePath(string path)
+                {
+                        if (string.IsNullOrWhiteSpace(path))
+                                return string.Empty;
+
+                        var index = path.LastIndexOf('/');
+                        if (index < 0)
+                                return string.Empty;
+
+                        return path.Substring(0, index + 1);
+                }
+
+                private readonly struct ManifestItem
+                {
+                        public ManifestItem(string id, string href, string? mediaType)
+                        {
+                                Id = id;
+                                Href = href;
+                                MediaType = mediaType;
+                        }
+
+                        public string Id { get; }
+
+                        public string Href { get; }
+
+                        public string? MediaType { get; }
                 }
         }
 }


### PR DESCRIPTION
## Summary
- extend the document reader service to load EPUB archives by extracting readable spine content
- normalize extracted XHTML to text for the document reader workflow
- add unit coverage that generates a sample EPUB and verifies the parsed output

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ed83e904832d96f6823c3063205c