### PR TITLE
Fix burger menu keyboard navigation behavior

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -174,6 +174,47 @@ namespace Dissonance.Tests.ViewModels
                         Assert.True(viewModel.IsHomeSelected);
                 }
 
+                [WindowsFact]
+                public void PendingNavigationSection_DoesNotChangeSelectedSection()
+                {
+                        var testEnvironment = CreateTestEnvironment(useDarkTheme: false);
+                        if (testEnvironment is null)
+                        {
+                                return;
+                        }
+
+                        var viewModel = testEnvironment.ViewModel;
+                        var targetSection = viewModel.NavigationSections.FirstOrDefault();
+                        Assert.NotNull(targetSection);
+
+                        viewModel.PendingNavigationSection = targetSection;
+
+                        Assert.Null(viewModel.SelectedSection);
+                        Assert.Same(targetSection, viewModel.PendingNavigationSection);
+                }
+
+                [WindowsFact]
+                public void SelectedSection_UpdatesPendingNavigationSection()
+                {
+                        var testEnvironment = CreateTestEnvironment(useDarkTheme: false);
+                        if (testEnvironment is null)
+                        {
+                                return;
+                        }
+
+                        var viewModel = testEnvironment.ViewModel;
+                        var targetSection = viewModel.NavigationSections.FirstOrDefault();
+                        Assert.NotNull(targetSection);
+
+                        viewModel.NavigateToSectionCommand.Execute(targetSection);
+
+                        Assert.Same(targetSection, viewModel.PendingNavigationSection);
+
+                        viewModel.NavigateToSectionCommand.Execute(null);
+
+                        Assert.Null(viewModel.PendingNavigationSection);
+                }
+
                 private static TestEnvironment? CreateTestEnvironment(bool useDarkTheme)
                 {
                         var synthesizer = new SpeechSynthesizer();

--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -47,6 +47,7 @@ namespace Dissonance.ViewModels
                 private string _lastAppliedHotkeyCombination = string.Empty;
                 private bool _autoReadClipboard;
                 private NavigationSectionViewModel? _selectedSection;
+                private NavigationSectionViewModel? _pendingNavigationSection;
                 private readonly string _previewStartLabel;
                 private readonly string _previewStopLabel;
                 private readonly string _previewToolTip;
@@ -259,10 +260,24 @@ namespace Dissonance.ViewModels
                                 _selectedSection = value;
                                 OnPropertyChanged ( nameof ( SelectedSection ) );
                                 OnPropertyChanged ( nameof ( IsHomeSelected ) );
+                                PendingNavigationSection = value;
                                 if ( value != null )
                                 {
                                         IsNavigationMenuOpen = false;
                                 }
+                        }
+                }
+
+                public NavigationSectionViewModel? PendingNavigationSection
+                {
+                        get => _pendingNavigationSection;
+                        set
+                        {
+                                if ( _pendingNavigationSection == value )
+                                        return;
+
+                                _pendingNavigationSection = value;
+                                OnPropertyChanged ( nameof ( PendingNavigationSection ) );
                         }
                 }
 

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -798,7 +798,7 @@
                                     Background="{DynamicResource CardBorderBrush}"/>
                             <ListBox x:Name="NavigationListBox"
                                      ItemsSource="{Binding NavigationSections}"
-                                     SelectedItem="{Binding SelectedSection, Mode=TwoWay}"
+                                     SelectedItem="{Binding PendingNavigationSection, Mode=TwoWay}"
                                      MinWidth="220"
                                      MaxHeight="320"
                                      BorderThickness="0"
@@ -808,6 +808,7 @@
                                      ToolTip="Select a section to open"
                                      TabIndex="1"
                                      PreviewKeyDown="NavigationListBox_PreviewKeyDown"
+                                     PreviewMouseLeftButtonUp="NavigationListBox_PreviewMouseLeftButtonUp"
                                      AutomationProperties.Name="Available sections"
                                      AutomationProperties.HelpText="Use the arrow keys to choose a section and press Enter to open it"
                                      SelectionMode="Single"

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -283,6 +283,7 @@ namespace Dissonance
 
                 private void NavigationMenuPopup_Opened ( object? sender, EventArgs e )
                 {
+                        _viewModel.PendingNavigationSection = _viewModel.SelectedSection;
                         Dispatcher.BeginInvoke ( new Action ( ( ) =>
                         {
                                 if ( NavigationHomeButton.IsVisible )
@@ -317,6 +318,18 @@ namespace Dissonance
                                 if ( NavigationMenuPopup.IsOpen )
                                 {
                                         NavigationMenuPopup.IsOpen = false;
+                                        e.Handled = true;
+                                }
+                        }
+                }
+
+                private void NavigationListBox_PreviewMouseLeftButtonUp ( object sender, MouseButtonEventArgs e )
+                {
+                        if ( NavigationListBox.SelectedItem is NavigationSectionViewModel section )
+                        {
+                                if ( _viewModel.NavigateToSectionCommand?.CanExecute ( section ) == true )
+                                {
+                                        _viewModel.NavigateToSectionCommand.Execute ( section );
                                         e.Handled = true;
                                 }
                         }


### PR DESCRIPTION
## Summary
- decouple the burger menu list selection from the active section by introducing a pending navigation selection in the view model
- reset the pending selection when the menu opens and trigger navigation on mouse clicks explicitly so keyboard navigation stays within the menu
- add unit tests covering the new pending navigation selection behavior

## Testing
- Not Run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3f26752fc832daf56744b87fc2ffd