### PR TITLE
Enable system-wide playback hotkeys for document reader

### DIFF
--- a/Dissonance/Dissonance.Tests/Services/HotkeyServiceTests.cs
+++ b/Dissonance/Dissonance.Tests/Services/HotkeyServiceTests.cs
@@ -20,10 +20,10 @@ public class HotkeyServiceTests
                         var parseMethod = typeof(HotkeyService).GetMethod("ParseModifiers", BindingFlags.NonPublic | BindingFlags.Instance);
                         Assert.NotNull(parseMethod);
 
-                        var result = (uint)parseMethod!.Invoke(service, new object[] { "Ctrl + Alt" })!;
+                        var result = (uint)parseMethod!.Invoke(service, new object[] { "Ctrl + Alt", false })!;
                         Assert.Equal(ModifierKeys.Control | ModifierKeys.Alt, result);
 
-                        result = (uint)parseMethod.Invoke(service, new object[] { "Shift+Win" })!;
+                        result = (uint)parseMethod.Invoke(service, new object[] { "Shift+Win", false })!;
                         Assert.Equal(ModifierKeys.Shift | ModifierKeys.Win, result);
                 });
         }
@@ -39,8 +39,11 @@ public class HotkeyServiceTests
                         var parseMethod = typeof(HotkeyService).GetMethod("ParseModifiers", BindingFlags.NonPublic | BindingFlags.Instance);
                         Assert.NotNull(parseMethod);
 
-                        Assert.Throws<TargetInvocationException>(() => parseMethod!.Invoke(service, new object[] { "Unknown" }));
-                        Assert.Throws<TargetInvocationException>(() => parseMethod.Invoke(service, new object[] { string.Empty }));
+                        Assert.Throws<TargetInvocationException>(() => parseMethod!.Invoke(service, new object[] { "Unknown", false }));
+                        Assert.Throws<TargetInvocationException>(() => parseMethod.Invoke(service, new object[] { string.Empty, false }));
+
+                        var zeroResult = (uint)parseMethod.Invoke(service, new object[] { string.Empty, true })!;
+                        Assert.Equal<uint>(0, zeroResult);
                 });
         }
 
@@ -58,7 +61,11 @@ public class HotkeyServiceTests
                         var wndProc = typeof(HotkeyService).GetMethod("WndProc", BindingFlags.NonPublic | BindingFlags.Instance);
                         Assert.NotNull(wndProc);
 
-                        var args = new object[] { IntPtr.Zero, WindowsMessages.Hotkey, IntPtr.Zero, IntPtr.Zero, false };
+                        var primaryField = typeof(HotkeyService).GetField("_primaryHotkeyId", BindingFlags.NonPublic | BindingFlags.Instance);
+                        Assert.NotNull(primaryField);
+                        primaryField!.SetValue(service, 42);
+
+                        var args = new object[] { IntPtr.Zero, WindowsMessages.Hotkey, new IntPtr(42), IntPtr.Zero, false };
                         wndProc!.Invoke(service, args);
 
                         Assert.Equal(1, invocationCount);

--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -9,6 +10,7 @@ using System.Speech.Synthesis;
 
 using Dissonance;
 using Dissonance.Services.DocumentReader;
+using Dissonance.Services.HotkeyService;
 using Dissonance.Services.SettingsService;
 using Dissonance.Services.TTSService;
 using Dissonance.ViewModels;
@@ -26,7 +28,8 @@ namespace Dissonance.Tests.ViewModels
                         var service = new StubDocumentReaderService(result);
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+                        var hotkeyService = new RecordingHotkeyService();
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, hotkeyService);
 
                         var success = await viewModel.LoadDocumentAsync(result.FilePath);
 
@@ -54,7 +57,7 @@ namespace Dissonance.Tests.ViewModels
                         var service = new FailingDocumentReaderService(new InvalidOperationException("boom"));
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, new RecordingHotkeyService());
 
                         var success = await viewModel.LoadDocumentAsync("missing.txt");
 
@@ -76,7 +79,7 @@ namespace Dissonance.Tests.ViewModels
                         var service = new StubDocumentReaderService(result);
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, new RecordingHotkeyService());
 
                         viewModel.ClearDocumentCommand.Execute(null);
 
@@ -95,7 +98,7 @@ namespace Dissonance.Tests.ViewModels
                         var service = new PendingDocumentReaderService(tcs);
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, new RecordingHotkeyService());
 
                         var loadTask = viewModel.LoadDocumentAsync("sample.txt");
 
@@ -116,7 +119,7 @@ namespace Dissonance.Tests.ViewModels
                         var settings = CreateSettings();
                         settings.DocumentReaderHotkey.Key = string.Empty;
                         var settingsService = new StubSettingsService(settings);
-                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, new RecordingHotkeyService());
 
                         viewModel.PlaybackHotkeyCombination = "MediaPlayPause";
 
@@ -130,6 +133,23 @@ namespace Dissonance.Tests.ViewModels
                         Assert.Equal("MediaPlayPause", settings.DocumentReaderHotkey.Key);
                         Assert.Equal(string.Empty, settings.DocumentReaderHotkey.Modifiers);
                         Assert.Equal(1, settingsService.SaveCalls);
+                        Assert.Contains("|MediaPlayPause|allowEmpty:True", hotkeyService.Registrations);
+                }
+
+                [Fact]
+                public void InitializesGlobalMediaKeyRegistrations()
+                {
+                        var result = new DocumentReadResult("sample.txt", "Hello world");
+                        var service = new StubDocumentReaderService(result);
+                        var settings = CreateSettings();
+                        var settingsService = new StubSettingsService(settings);
+                        var hotkeyService = new RecordingHotkeyService();
+
+                        _ = new DocumentReaderViewModel(service, new StubTtsService(), settingsService, hotkeyService);
+
+                        Assert.Contains("|MediaPlayPause|allowEmpty:True", hotkeyService.Registrations);
+                        Assert.Contains("|MediaPlay|allowEmpty:True", hotkeyService.Registrations);
+                        Assert.Contains("|MediaPause|allowEmpty:True", hotkeyService.Registrations);
                 }
 
                 [Fact]
@@ -140,7 +160,7 @@ namespace Dissonance.Tests.ViewModels
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
                         var ttsService = new StubTtsService(returnPrompt: true);
-                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService, new RecordingHotkeyService());
 
                         await viewModel.LoadDocumentAsync(result.FilePath);
 
@@ -167,7 +187,7 @@ namespace Dissonance.Tests.ViewModels
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
                         var ttsService = new StubTtsService(returnPrompt: true);
-                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService, new RecordingHotkeyService());
 
                         await viewModel.LoadDocumentAsync(result.FilePath);
 
@@ -195,7 +215,7 @@ namespace Dissonance.Tests.ViewModels
                         var settings = CreateSettings();
                         var settingsService = new StubSettingsService(settings);
                         var ttsService = new StubTtsService(returnPrompt: true);
-                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService);
+                        var viewModel = new DocumentReaderViewModel(service, ttsService, settingsService, new RecordingHotkeyService());
 
                         await viewModel.LoadDocumentAsync(result.FilePath);
 
@@ -307,6 +327,66 @@ namespace Dissonance.Tests.ViewModels
                         public Task<DocumentReadResult> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
                         {
                                 return _completion.Task;
+                        }
+                }
+
+                private sealed class RecordingHotkeyService : IHotkeyService
+                {
+                        public List<string> PrimaryRegistrations { get; } = new();
+                        public List<string> Registrations { get; } = new();
+                        public List<string> DisposedRegistrations { get; } = new();
+
+                        public event Action? HotkeyPressed
+                        {
+                                add { }
+                                remove { }
+                        }
+
+                        public void Dispose()
+                        {
+                        }
+
+                        public void Initialize(System.Windows.Window mainWindow)
+                        {
+                        }
+
+                        public void RegisterHotkey(AppSettings.HotkeySettings hotkey)
+                        {
+                                PrimaryRegistrations.Add($"{hotkey.Modifiers}|{hotkey.Key}");
+                        }
+
+                        public IDisposable? RegisterHotkey(AppSettings.HotkeySettings hotkey, Action callback, bool allowEmptyModifiers = false)
+                        {
+                                var descriptor = $"{hotkey.Modifiers}|{hotkey.Key}|allowEmpty:{allowEmptyModifiers}";
+                                Registrations.Add(descriptor);
+                                return new RecordingRegistration(this, descriptor);
+                        }
+
+                        public void UnregisterHotkey()
+                        {
+                                PrimaryRegistrations.Clear();
+                        }
+
+                        private sealed class RecordingRegistration : IDisposable
+                        {
+                                private readonly RecordingHotkeyService _owner;
+                                private readonly string _descriptor;
+                                private bool _disposed;
+
+                                public RecordingRegistration(RecordingHotkeyService owner, string descriptor)
+                                {
+                                        _owner = owner;
+                                        _descriptor = descriptor;
+                                }
+
+                                public void Dispose()
+                                {
+                                        if (_disposed)
+                                                return;
+
+                                        _owner.DisposedRegistrations.Add(_descriptor);
+                                        _disposed = true;
+                                }
                         }
                 }
 

--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -213,7 +213,7 @@ namespace Dissonance.Tests.ViewModels
                         var clipboardService = new TestClipboardService();
                         var statusService = new TestStatusAnnouncementService();
                         var documentReaderService = new TestDocumentReaderService();
-                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService, ttsService, settingsService);
+                        var documentReaderViewModel = new DocumentReaderViewModel(documentReaderService, ttsService, settingsService, hotkeyService);
                         var clipboardManager = new ClipboardManager(clipboardService, new TestLogger<ClipboardManager>(), statusService);
 
                         var viewModel = new MainWindowViewModel(settingsService, ttsService, hotkeyService, themeService, messageService, clipboardManager, statusService, documentReaderViewModel);
@@ -373,6 +373,7 @@ namespace Dissonance.Tests.ViewModels
                 private sealed class TestHotkeyService : IHotkeyService
                 {
                         public string? LastRegisteredHotkey { get; private set; }
+                        public List<string> AdditionalRegistrations { get; } = new();
 
                         public event Action? HotkeyPressed
                         {
@@ -393,9 +394,22 @@ namespace Dissonance.Tests.ViewModels
                                 LastRegisteredHotkey = $"{hotkey.Modifiers}+{hotkey.Key}";
                         }
 
+                        public IDisposable? RegisterHotkey(AppSettings.HotkeySettings hotkey, Action callback, bool allowEmptyModifiers = false)
+                        {
+                                AdditionalRegistrations.Add($"{hotkey.Modifiers}|{hotkey.Key}|allowEmpty:{allowEmptyModifiers}");
+                                return new StubRegistration();
+                        }
+
                         public void UnregisterHotkey()
                         {
                                 LastRegisteredHotkey = null;
+                        }
+
+                        private sealed class StubRegistration : IDisposable
+                        {
+                                public void Dispose()
+                                {
+                                }
                         }
                 }
 

--- a/Dissonance/Dissonance/Services/HotkeyService/IHotkeyService.cs
+++ b/Dissonance/Dissonance/Services/HotkeyService/IHotkeyService.cs
@@ -2,14 +2,16 @@
 
 namespace Dissonance.Services.HotkeyService
 {
-	public interface IHotkeyService : IDisposable
-	{
-		event Action HotkeyPressed;
+        public interface IHotkeyService : IDisposable
+        {
+                event Action HotkeyPressed;
 
-		void Initialize ( Window mainWindow );
+                void Initialize ( Window mainWindow );
 
-		void RegisterHotkey ( AppSettings.HotkeySettings hotkey );
+                void RegisterHotkey ( AppSettings.HotkeySettings hotkey );
 
-		void UnregisterHotkey ( );
-	}
+                IDisposable? RegisterHotkey ( AppSettings.HotkeySettings hotkey, Action callback, bool allowEmptyModifiers = false );
+
+                void UnregisterHotkey ( );
+        }
 }


### PR DESCRIPTION
## Summary
- extend the hotkey service to support multiple registrations and media keys without modifiers
- register the document reader playback shortcut and media keys with the global hotkey service
- update hotkey and document reader tests to cover the new registration flow

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f12a8214832dbde54d6c20b22edc