### PR TITLE
Improve hotkey capture tab navigation

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -328,12 +328,21 @@ namespace Dissonance
 
                         if ( key == Key.Tab )
                         {
-                                var modifiersState = Keyboard.Modifiers;
-                                if ( modifiersState == ModifierKeys.None || modifiersState == ModifierKeys.Shift )
+                                if ( sender is UIElement focusElement )
+                                {
+                                        var direction = ( Keyboard.Modifiers & ModifierKeys.Shift ) == ModifierKeys.Shift
+                                                ? FocusNavigationDirection.Previous
+                                                : FocusNavigationDirection.Next;
+
+                                        e.Handled = true;
+                                        focusElement.MoveFocus ( new TraversalRequest ( direction ) );
+                                }
+                                else
                                 {
                                         e.Handled = false;
-                                        return;
                                 }
+
+                                return;
                         }
 
                         e.Handled = true;
@@ -366,12 +375,13 @@ namespace Dissonance
 
                         if ( key == Key.Tab )
                         {
-                                var modifiersState = Keyboard.Modifiers;
-                                if ( modifiersState == ModifierKeys.None || modifiersState == ModifierKeys.Shift )
-                                {
-                                        e.Handled = false;
-                                        return;
-                                }
+                                var direction = ( Keyboard.Modifiers & ModifierKeys.Shift ) == ModifierKeys.Shift
+                                        ? FocusNavigationDirection.Previous
+                                        : FocusNavigationDirection.Next;
+
+                                e.Handled = true;
+                                textBox.MoveFocus ( new TraversalRequest ( direction ) );
+                                return;
                         }
 
                         if ( key == Key.Back || key == Key.Delete || key == Key.Escape )


### PR DESCRIPTION
## Summary
- ensure the clipboard hotkey capture field moves focus to the Apply button when tabbing for better accessibility
- mirror the same tab-handling behavior for the document playback hotkey capture field so the flow is consistent across hotkey editors

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3f328d29c832d99a8e1698f322776