### PR TITLE
Refine document reader messaging

### DIFF
--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -165,9 +165,9 @@ namespace Dissonance.ViewModels
                         _navigationSections.Add ( new NavigationSectionViewModel (
                                 "document-reader",
                                 "Document Reader",
-                                "Load saved documents and prepare them for narration.",
+                                "Load saved documents and listen as they're narrated.",
                                 "Document Reader",
-                                "Open text files and review their contents before listening.",
+                                "Open text files and follow along while Dissonance reads them aloud.",
                                 _documentReaderViewModel ) );
                 }
 

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -84,7 +84,7 @@
 
                 <StackPanel Grid.Row="0"
                             Margin="0,0,0,20">
-                    <TextBlock Text="Open a text document to review it before narration."
+                    <TextBlock Text="Open a text document to hear it narrated."
                                Style="{StaticResource CardDescriptionTextStyle}"/>
                 </StackPanel>
 


### PR DESCRIPTION
## Summary
- update the document reader tooltips, headings, and accessibility text to emphasize reading instead of previewing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f37aa950832d8dc9137ef9837729