### PR TITLE
Enable document reader playback from user selection

### DIFF
--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -405,13 +405,15 @@
                                         </ListBox>
                                     </StackPanel>
                                 </Border>
-                                <controls:HighlightingFlowDocumentScrollViewer Grid.Column="1"
+                                <controls:HighlightingFlowDocumentScrollViewer x:Name="DocumentReaderViewer"
+                                                                              Grid.Column="1"
                                                                               Document="{Binding Document}"
                                                                               HighlightStartIndex="{Binding HighlightStartIndex}"
                                                                               HighlightLength="{Binding HighlightLength}"
                                                                               HighlightBrush="{Binding HighlightBrush}"
                                                                               VerticalScrollBarVisibility="Auto"
                                                                               TabIndex="11"
+                                                                              SelectionChanged="DocumentReaderViewer_SelectionChanged"
                                                                               AutomationProperties.Name="Document reader content"
                                                                               AutomationProperties.HelpText="Displays the loaded document for reading with highlighted narration text"
                                                                               ToolTip="Reader view of the loaded document">

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Threading;
 
 using Dissonance.Services.SettingsService;
 using Dissonance.ViewModels;
+using Dissonance.Windows.Controls;
 
 namespace Dissonance
 {
@@ -495,6 +496,15 @@ namespace Dissonance
                         }
 
                         return modifiers;
+                }
+
+                private void DocumentReaderViewer_SelectionChanged ( object sender, RoutedEventArgs e )
+                {
+                        if ( sender is not HighlightingFlowDocumentScrollViewer viewer )
+                                return;
+
+                        var selectedText = string.IsNullOrEmpty ( viewer.SelectedText ) ? null : viewer.SelectedText;
+                        _documentReaderViewModel.UpdateSelectionRange ( viewer.SelectionStartIndex, viewer.SelectionLength, selectedText );
                 }
 
                 private void VoiceVolumeSlider_KeyDown ( object sender, KeyEventArgs e )


### PR DESCRIPTION
## Summary
- surface the reader control's caret and selection so the view model can track them
- start narration from the current caret or selected text and clamp highlighting to the spoken span
- add tests covering playback from a selection and caret-only updates

## Testing
- dotnet test *(fails: `dotnet` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e560273ee8832d8c7e5791c0e39c3a