### PR TITLE
Improve FlowDocument pointer caching

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -45,14 +45,15 @@ namespace Dissonance.Tests.ViewModels
 
                                 Assert.Equal(sampleText, normalizedRendered);
 
+                                var viewer = new HighlightingFlowDocumentScrollViewer { Document = document };
                                 var getPointer = typeof(HighlightingFlowDocumentScrollViewer)
-                                        .GetMethod("GetTextPointerAtOffset", BindingFlags.NonPublic | BindingFlags.Static);
+                                        .GetMethod("GetTextPointerAtOffset", BindingFlags.NonPublic | BindingFlags.Instance);
                                 Assert.NotNull(getPointer);
 
                                 for (var index = 0; index < sampleText.Length; index++)
                                 {
-                                        var startPointer = (TextPointer?)getPointer!.Invoke(null, new object[] { document, index });
-                                        var endPointer = (TextPointer?)getPointer.Invoke(null, new object[] { document, index + 1 });
+                                        var startPointer = (TextPointer?)getPointer!.Invoke(viewer, new object[] { document, index });
+                                        var endPointer = (TextPointer?)getPointer.Invoke(viewer, new object[] { document, index + 1 });
 
                                         Assert.NotNull(startPointer);
                                         Assert.NotNull(endPointer);

--- a/Dissonance/Dissonance.Tests/Windows/Controls/HighlightingFlowDocumentScrollViewerTests.cs
+++ b/Dissonance/Dissonance.Tests/Windows/Controls/HighlightingFlowDocumentScrollViewerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+using Dissonance.Tests.TestInfrastructure;
+using Dissonance.Windows.Controls;
+
+using Xunit;
+
+namespace Dissonance.Tests.Windows.Controls
+{
+        public class HighlightingFlowDocumentScrollViewerTests
+        {
+                [WindowsFact]
+                public void IncrementalHighlightUpdatesUsePointerCache()
+                {
+                        const int iterations = 5000;
+                        const int highlightLength = 8;
+                        const int documentLength = 200_000;
+
+                        StaTestRunner.Run(() =>
+                        {
+                                WpfTestHelper.EnsureApplication();
+
+                                var viewer = new HighlightingFlowDocumentScrollViewer();
+                                var document = new FlowDocument();
+                                var paragraph = new Paragraph(new Run(new string('a', documentLength)));
+                                document.Blocks.Add(paragraph);
+
+                                viewer.Document = document;
+                                viewer.HighlightBrush = Brushes.Yellow;
+                                viewer.HighlightLength = highlightLength;
+
+                                var getPointerMethod = typeof(HighlightingFlowDocumentScrollViewer)
+                                        .GetMethod("GetTextPointerAtOffset", BindingFlags.NonPublic | BindingFlags.Instance);
+                                var getOffsetMethod = typeof(HighlightingFlowDocumentScrollViewer)
+                                        .GetMethod("GetOffsetFromPointer", BindingFlags.NonPublic | BindingFlags.Instance);
+                                Assert.NotNull(getPointerMethod);
+                                Assert.NotNull(getOffsetMethod);
+
+                                var stopwatch = Stopwatch.StartNew();
+
+                                for (var i = 0; i < iterations; i++)
+                                {
+                                        viewer.HighlightStartIndex = i;
+
+                                        var pointer = (TextPointer?)getPointerMethod!.Invoke(viewer, new object[] { document, i });
+                                        Assert.NotNull(pointer);
+
+                                        var offset = (int)getOffsetMethod!.Invoke(viewer, new object[] { document, pointer! });
+                                        Assert.Equal(i, offset);
+                                }
+
+                                stopwatch.Stop();
+
+                                Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+                                        $"Incremental highlights took too long: {stopwatch.Elapsed}.");
+
+                                var finalStartPointer = (TextPointer?)getPointerMethod!.Invoke(viewer, new object[] { document, iterations - 1 });
+                                var finalEndPointer = (TextPointer?)getPointerMethod.Invoke(viewer, new object[] { document, iterations - 1 + highlightLength });
+                                Assert.NotNull(finalStartPointer);
+                                Assert.NotNull(finalEndPointer);
+
+                                var highlightRange = new TextRange(finalStartPointer!, finalEndPointer!);
+                                Assert.Equal(new string('a', highlightLength), highlightRange.Text);
+
+                                viewer.HighlightLength = 0;
+
+                                var cacheValidField = typeof(HighlightingFlowDocumentScrollViewer)
+                                        .GetField("_cacheValid", BindingFlags.NonPublic | BindingFlags.Instance);
+                                Assert.NotNull(cacheValidField);
+                                Assert.False((bool)cacheValidField!.GetValue(viewer)!);
+
+                                var highlightField = typeof(HighlightingFlowDocumentScrollViewer)
+                                        .GetField("_currentHighlight", BindingFlags.NonPublic | BindingFlags.Instance);
+                                Assert.NotNull(highlightField);
+                                Assert.Null(highlightField!.GetValue(viewer));
+
+                                var newDocument = new FlowDocument(new Paragraph(new Run("reset")));
+                                viewer.Document = newDocument;
+
+                                var cachedOffsetField = typeof(HighlightingFlowDocumentScrollViewer)
+                                        .GetField("_cachedOffset", BindingFlags.NonPublic | BindingFlags.Instance);
+                                Assert.NotNull(cachedOffsetField);
+                                Assert.Equal(0, (int)cachedOffsetField!.GetValue(viewer)!);
+
+                                var resetPointer = (TextPointer?)getPointerMethod.Invoke(viewer, new object[] { newDocument, 0 });
+                                Assert.NotNull(resetPointer);
+                                Assert.Equal(newDocument.ContentStart, resetPointer);
+                        });
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- cache the last FlowDocument TextPointer/offset pair inside HighlightingFlowDocumentScrollViewer and reset it on document/highlight clears
- reuse the cached pointer for both highlight application and selection publishing to avoid restarting from ContentStart
- add a regression test that exercises thousands of incremental highlight updates on a large FlowDocument to validate correctness and performance

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea44f4aac0832db3088afcedc769f0