### PR TITLE
Add pause/resume handling for document reader TTS

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -406,6 +406,14 @@ namespace Dissonance.Tests.ViewModels
                                 return LastPrompt;
                         }
 
+                        public void Pause()
+                        {
+                        }
+
+                        public void Resume()
+                        {
+                        }
+
                         public void Stop()
                         {
                         }

--- a/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/ITTSService.cs
@@ -9,6 +9,10 @@ namespace Dissonance.Services.TTSService
 
                 Prompt? Speak ( string text );
 
+                void Pause ( );
+
+                void Resume ( );
+
                 void Stop ( );
 
                 event EventHandler<SpeakCompletedEventArgs> SpeechCompleted;

--- a/Dissonance/Dissonance/Services/TTSService/TTSService.cs
+++ b/Dissonance/Dissonance/Services/TTSService/TTSService.cs
@@ -71,6 +71,36 @@ namespace Dissonance.Services.TTSService
                         }
                 }
 
+                public void Pause ( )
+                {
+                        try
+                        {
+                                if ( _synthesizer.State == SynthesizerState.Speaking )
+                                {
+                                        _synthesizer.Pause ( );
+                                }
+                        }
+                        catch ( Exception ex )
+                        {
+                                _messageService.DissonanceMessageBoxShowError ( MessageBoxTitles.TTSServiceError, "Failed to pause speaking text due to an unhandled exception.", ex );
+                        }
+                }
+
+                public void Resume ( )
+                {
+                        try
+                        {
+                                if ( _synthesizer.State == SynthesizerState.Paused )
+                                {
+                                        _synthesizer.Resume ( );
+                                }
+                        }
+                        catch ( Exception ex )
+                        {
+                                _messageService.DissonanceMessageBoxShowError ( MessageBoxTitles.TTSServiceError, "Failed to resume speaking text due to an unhandled exception.", ex );
+                        }
+                }
+
                 public void Stop ( )
                 {
                         try


### PR DESCRIPTION
## Summary
- add Pause and Resume operations to the TTS service interface and implementation
- update the document reader view model to use native pause/resume without restarting prompts while maintaining progress tracking
- extend unit tests with pause/resume coverage and enhanced TTS stubs

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea50aafe7c832d9181b1aa9e1070c9