### PR TITLE
Optimize selection handling in document reader

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -308,7 +308,7 @@ namespace Dissonance.Tests.ViewModels
 
                         await viewModel.LoadDocumentAsync(result.FilePath);
 
-                        viewModel.UpdateSelectionRange(6, 5, "brave");
+                        viewModel.UpdateSelectionRange(6, 5);
                         viewModel.PlayPauseCommand.Execute(null);
 
                         Assert.True(viewModel.IsPlaying);
@@ -327,7 +327,7 @@ namespace Dissonance.Tests.ViewModels
 
                         await viewModel.LoadDocumentAsync(result.FilePath);
 
-                        viewModel.UpdateSelectionRange(4, 0, null);
+                        viewModel.UpdateSelectionRange(4, 0);
 
                         Assert.Equal(4, viewModel.CurrentCharacterIndex);
                         Assert.Equal(TimeSpan.FromSeconds(4 / 15d), viewModel.CurrentAudioPosition);

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -1033,9 +1033,9 @@ namespace Dissonance.ViewModels
                                         CurrentAudioPosition = _playbackStartAudioPosition;
                                         _activePlaybackLength = selectionLength;
                                         SetHighlightRange(selectionStart, 0);
-                                        var textToSpeak = PlainText.Substring(selectionStart, selectionLength);
+                                        var textToSpeakSelection = PlainText.Substring(selectionStart, selectionLength);
 
-                                        _currentPrompt = _ttsService.Speak(textToSpeak);
+                                        _currentPrompt = _ttsService.Speak(textToSpeakSelection);
                                         _pendingSeekCharacterIndex = null;
                                         _pendingSeekAudioPosition = TimeSpan.Zero;
 

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -64,7 +64,6 @@ namespace Dissonance.ViewModels
                 private bool _playbackHotkeyTogglesPause;
                 private int? _selectionStartIndex;
                 private int _selectionLength;
-                private string? _selectionTextCache;
                 private int _activePlaybackLength;
                 private readonly IReadOnlyList<HighlightColorOption> _highlightColorOptions;
                 private HighlightColorOption _selectedHighlightColor = null!;
@@ -476,18 +475,16 @@ namespace Dissonance.ViewModels
                         _sections.Clear();
                         SelectedSection = null;
                         ResetPlaybackState();
-                        _selectionTextCache = null;
                         if (RememberDocumentProgress)
                                 ClearPersistedDocumentState();
                 }
 
-                public void UpdateSelectionRange(int startIndex, int length, string? selectedText)
+                public void UpdateSelectionRange(int startIndex, int length)
                 {
                         if (PlainText == null)
                         {
                                 _selectionStartIndex = null;
                                 _selectionLength = 0;
-                                _selectionTextCache = null;
                                 return;
                         }
 
@@ -499,9 +496,6 @@ namespace Dissonance.ViewModels
 
                         _selectionStartIndex = normalizedStart;
                         _selectionLength = normalizedLength;
-                        _selectionTextCache = normalizedLength > 0 && !string.IsNullOrEmpty(selectedText)
-                                ? selectedText
-                                : null;
 
                         if (IsPaused && _currentPrompt != null)
                         {
@@ -1039,12 +1033,7 @@ namespace Dissonance.ViewModels
                                         CurrentAudioPosition = _playbackStartAudioPosition;
                                         _activePlaybackLength = selectionLength;
                                         SetHighlightRange(selectionStart, 0);
-                                        var textToSpeak = _selectionTextCache;
-                                        if (textToSpeak == null || textToSpeak.Length != selectionLength)
-                                        {
-                                                textToSpeak = PlainText.Substring(selectionStart, selectionLength);
-                                                _selectionTextCache = textToSpeak;
-                                        }
+                                        var textToSpeak = PlainText.Substring(selectionStart, selectionLength);
 
                                         _currentPrompt = _ttsService.Speak(textToSpeak);
                                         _pendingSeekCharacterIndex = null;
@@ -1166,7 +1155,6 @@ namespace Dissonance.ViewModels
                         _pendingSeekAudioPosition = TimeSpan.Zero;
                         _selectionStartIndex = null;
                         _selectionLength = 0;
-                        _selectionTextCache = null;
                         _activePlaybackLength = 0;
                         _resumeRequiresRestart = false;
                         var previousSuppressed = _suspendProgressPersistence;

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -503,8 +503,7 @@ namespace Dissonance
                         if ( sender is not HighlightingFlowDocumentScrollViewer viewer )
                                 return;
 
-                        var selectedText = string.IsNullOrEmpty ( viewer.SelectedText ) ? null : viewer.SelectedText;
-                        _documentReaderViewModel.UpdateSelectionRange ( viewer.SelectionStartIndex, viewer.SelectionLength, selectedText );
+                        _documentReaderViewModel.UpdateSelectionRange ( viewer.SelectionStartIndex, viewer.SelectionLength );
                 }
 
                 private void VoiceVolumeSlider_KeyDown ( object sender, KeyEventArgs e )


### PR DESCRIPTION
## Summary
- gate selection text extraction in the highlighting flow document viewer to avoid unnecessary allocations
- update document reader selection handling to depend on selection start/length and derive text lazily
- adjust unit tests for the revised selection contract

## Testing
- dotnet test *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea744cf620832dbb234ad33368e918