### PR TITLE
Delay document reader resume until activation

### DIFF
--- a/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
+++ b/Dissonance/Dissonance.Tests/ViewModels/DocumentReaderViewModelTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Documents;
@@ -333,6 +336,105 @@ namespace Dissonance.Tests.ViewModels
                         Assert.Equal(TimeSpan.FromSeconds(4 / 15d), viewModel.CurrentAudioPosition);
                         Assert.Equal(4, viewModel.HighlightStartIndex);
                         Assert.Equal(0, viewModel.HighlightLength);
+                }
+
+                [Fact]
+                public async Task EnsureInitializedAsync_RestoresProgressAfterBackgroundValidationCompletes()
+                {
+                        var sampleText = "Sample document text for restoration";
+                        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+                        await File.WriteAllTextAsync(tempFile, sampleText);
+
+                        try
+                        {
+                                var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sampleText));
+                                var fileInfo = new FileInfo(tempFile);
+                                fileInfo.Refresh();
+
+                                var settings = CreateSettings();
+                                settings.RememberDocumentReaderPosition = true;
+                                settings.DocumentReaderResumeState = new AppSettings.DocumentReaderResumeSnapshot
+                                {
+                                        FilePath = tempFile,
+                                        CharacterIndex = 10,
+                                        DocumentLength = sampleText.Length,
+                                        ContentHash = Convert.ToHexString(hash),
+                                        FileSize = fileInfo.Length,
+                                        LastWriteTimeUtc = fileInfo.LastWriteTimeUtc,
+                                };
+
+                                var service = new StubDocumentReaderService(new DocumentReadResult(tempFile, sampleText));
+                                var settingsService = new StubSettingsService(settings);
+                                var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+
+                                await viewModel.EnsureInitializedAsync();
+
+                                Assert.NotNull(viewModel.Document);
+                                Assert.Equal(0, viewModel.CurrentCharacterIndex);
+                                Assert.Equal(0, settingsService.SaveCalls);
+
+                                var restorationTask = viewModel.ResumeRestorationTask;
+                                Assert.NotNull(restorationTask);
+
+                                if (restorationTask != null)
+                                        await restorationTask;
+
+                                Assert.Equal(10, viewModel.CurrentCharacterIndex);
+                                Assert.True(settingsService.SaveCalls > 0);
+                        }
+                        finally
+                        {
+                                if (File.Exists(tempFile))
+                                        File.Delete(tempFile);
+                        }
+                }
+
+                [Fact]
+                public async Task EnsureInitializedAsync_ResetsProgressWhenMetadataDiffers()
+                {
+                        var sampleText = "Sample document text for restoration";
+                        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+                        await File.WriteAllTextAsync(tempFile, sampleText);
+
+                        try
+                        {
+                                var mismatchedHash = SHA256.HashData(Encoding.UTF8.GetBytes(sampleText + "!"));
+                                var fileInfo = new FileInfo(tempFile);
+                                fileInfo.Refresh();
+
+                                var settings = CreateSettings();
+                                settings.RememberDocumentReaderPosition = true;
+                                settings.DocumentReaderResumeState = new AppSettings.DocumentReaderResumeSnapshot
+                                {
+                                        FilePath = tempFile,
+                                        CharacterIndex = 12,
+                                        DocumentLength = sampleText.Length,
+                                        ContentHash = Convert.ToHexString(mismatchedHash),
+                                        FileSize = fileInfo.Length,
+                                        LastWriteTimeUtc = fileInfo.LastWriteTimeUtc,
+                                };
+
+                                var service = new StubDocumentReaderService(new DocumentReadResult(tempFile, sampleText));
+                                var settingsService = new StubSettingsService(settings);
+                                var viewModel = new DocumentReaderViewModel(service, new StubTtsService(), settingsService);
+
+                                await viewModel.EnsureInitializedAsync();
+
+                                var restorationTask = viewModel.ResumeRestorationTask;
+                                Assert.NotNull(restorationTask);
+
+                                if (restorationTask != null)
+                                        await restorationTask;
+
+                                Assert.Equal(0, viewModel.CurrentCharacterIndex);
+                                Assert.Equal("The previously saved document has changed. Progress was reset.", viewModel.StatusMessage);
+                                Assert.True(settingsService.SaveCalls > 0);
+                        }
+                        finally
+                        {
+                                if (File.Exists(tempFile))
+                                        File.Delete(tempFile);
+                        }
                 }
 
                 private static AppSettings CreateSettings()

--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -1062,14 +1062,14 @@ namespace Dissonance.ViewModels
                                         CurrentAudioPosition = _playbackStartAudioPosition;
                                         _activePlaybackLength = selectionLength;
                                         SetHighlightRange(selectionStart, 0);
-                                        var textToSpeak = _selectionTextCache;
-                                        if (textToSpeak == null || textToSpeak.Length != selectionLength)
+                                        var textToSpeakLocal = _selectionTextCache;
+                                        if (textToSpeakLocal == null || textToSpeakLocal.Length != selectionLength)
                                         {
-                                                textToSpeak = PlainText.Substring(selectionStart, selectionLength);
-                                                _selectionTextCache = textToSpeak;
+                                                textToSpeakLocal = PlainText.Substring(selectionStart, selectionLength);
+                                                _selectionTextCache = textToSpeakLocal;
                                         }
 
-                                        _currentPrompt = _ttsService.Speak(textToSpeak);
+                                        _currentPrompt = _ttsService.Speak(textToSpeakLocal);
                                         _pendingSeekCharacterIndex = null;
                                         _pendingSeekAudioPosition = TimeSpan.Zero;
 

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml
@@ -76,7 +76,7 @@
             </Setter>
         </Style>
         <DataTemplate DataType="{x:Type local:DocumentReaderViewModel}">
-            <Grid>
+            <Grid Loaded="DocumentReaderView_Loaded">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>

--- a/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
+++ b/Dissonance/Dissonance/Windows/MainWindow.xaml.cs
@@ -465,6 +465,24 @@ namespace Dissonance
                         InputBindings.Add ( _documentPlaybackKeyBinding );
                 }
 
+                private async void DocumentReaderView_Loaded ( object sender, RoutedEventArgs e )
+                {
+                        if ( sender is not FrameworkElement element )
+                                return;
+
+                        if ( element.DataContext is DocumentReaderViewModel documentReaderViewModel )
+                        {
+                                try
+                                {
+                                        await documentReaderViewModel.EnsureInitializedAsync ( );
+                                }
+                                catch ( OperationCanceledException )
+                                {
+                                        // Ignore cancellation during initialization.
+                                }
+                        }
+                }
+
                 private static bool IsModifierKey ( Key key )
                 {
                         return ModifierKeySet.Contains ( key );


### PR DESCRIPTION
## Summary
- delay document reader resume initialization until the view is activated and reuse persisted metadata while background validation runs
- trigger the asynchronous initialization from the document reader template
- add regression coverage to verify background restoration and persistence behavior

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea74537344832db29e25ee2b3bf256