### PR TITLE
Defer document reader resume until activation

### DIFF
--- a/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/MainWindowViewModel.cs
@@ -264,6 +264,10 @@ namespace Dissonance.ViewModels
                                 if ( value != null )
                                 {
                                         IsNavigationMenuOpen = false;
+                                        if ( value.ContentViewModel == _documentReaderViewModel )
+                                        {
+                                                _ = _documentReaderViewModel.InitializeAsync ( );
+                                        }
                                 }
                         }
                 }


### PR DESCRIPTION
## Summary
- add an InitializeAsync entry point on DocumentReaderViewModel and trigger it when the Document Reader tab is selected
- reuse persisted resume metadata and recompute hashes/file info on a background task before updating settings
- expand unit tests to cover deferred initialization and ensure progress persistence once background work completes

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eaa858906c832db11225164612571a