### PR TITLE
Optimize highlight pointer cache handling

### DIFF
--- a/Dissonance/Dissonance.Tests/Windows/Controls/HighlightingFlowDocumentScrollViewerTests.cs
+++ b/Dissonance/Dissonance.Tests/Windows/Controls/HighlightingFlowDocumentScrollViewerTests.cs
@@ -72,7 +72,11 @@ namespace Dissonance.Tests.Windows.Controls
                                 var cacheValidField = typeof(HighlightingFlowDocumentScrollViewer)
                                         .GetField("_cacheValid", BindingFlags.NonPublic | BindingFlags.Instance);
                                 Assert.NotNull(cacheValidField);
-                                Assert.False((bool)cacheValidField!.GetValue(viewer)!);
+                                Assert.True((bool)cacheValidField!.GetValue(viewer)!);
+
+                                viewer.HighlightStartIndex = 0;
+
+                                Assert.False((bool)cacheValidField.GetValue(viewer)!);
 
                                 var highlightField = typeof(HighlightingFlowDocumentScrollViewer)
                                         .GetField("_currentHighlight", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
+++ b/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
@@ -214,8 +214,19 @@ namespace Dissonance.Windows.Controls
                         }
 
                         var highlightLength = HighlightLength;
+                        var previousAppliedStart = _appliedStartIndex;
                         if (highlightLength <= 0)
                         {
+                                if (_cacheValid)
+                                {
+                                        var movedBackward = previousAppliedStart >= 0
+                                                ? HighlightStartIndex < previousAppliedStart
+                                                : HighlightStartIndex < _cachedOffset;
+
+                                        if (movedBackward)
+                                                ResetPointerCache();
+                                }
+
                                 ClearHighlight();
                                 _appliedStartIndex = -1;
                                 _appliedLength = 0;

--- a/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
+++ b/Dissonance/Dissonance/Windows/Controls/HighlightingFlowDocumentScrollViewer.cs
@@ -220,7 +220,6 @@ namespace Dissonance.Windows.Controls
                                 _appliedStartIndex = -1;
                                 _appliedLength = 0;
                                 _appliedBrush = HighlightBrush;
-                                ResetPointerCache();
                                 return;
                         }
 
@@ -352,6 +351,12 @@ namespace Dissonance.Windows.Controls
                         EnsurePointerCache(document);
 
                         var targetOffset = Math.Max(0, offset);
+
+                        if (_cacheValid && _cachedPointer != null && targetOffset < _cachedOffset)
+                        {
+                                ResetPointerCache();
+                                EnsurePointerCache(document);
+                        }
                         var (navigator, currentOffset) = GetStartingPointer(document, targetOffset);
                         var pointer = AdvanceToOffset(document, navigator, currentOffset, targetOffset, out var newPointer, out var newOffset);
 
@@ -366,6 +371,12 @@ namespace Dissonance.Windows.Controls
                                 return 0;
 
                         EnsurePointerCache(document);
+
+                        if (_cacheValid && _cachedPointer != null && pointer != null && pointer.CompareTo(_cachedPointer) < 0)
+                        {
+                                ResetPointerCache();
+                                EnsurePointerCache(document);
+                        }
 
                         var (navigator, currentOffset) = GetStartingPointer(document, pointer);
                         var offset = AdvanceToPointer(document, navigator, currentOffset, pointer, out var newPointer, out var newOffset);


### PR DESCRIPTION
## Summary
- avoid resetting the cached text pointer when clearing zero-length highlights to preserve forward navigation speed
- reset the pointer cache only when seeking backwards within the same FlowDocument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eab2046858832d956b7572104ceecb