### PR TITLE
Simplify FlowDocument creation for document reader

### DIFF
--- a/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
+++ b/Dissonance/Dissonance/ViewModels/DocumentReaderViewModel.cs
@@ -906,47 +906,9 @@ namespace Dissonance.ViewModels
                                 return document;
 
                         var normalized = content.Replace("\r\n", "\n").Replace('\r', '\n');
-                        var length = normalized.Length;
-                        var paragraphStart = 0;
+                        var normalizedContent = normalized.Replace("\n", Environment.NewLine);
 
-                        while (paragraphStart <= length)
-                        {
-                                var separatorIndex = normalized.IndexOf("\n\n", paragraphStart, StringComparison.Ordinal);
-                                var paragraphEnd = separatorIndex >= 0 ? separatorIndex : length;
-                                var paragraphSpan = normalized.AsSpan(paragraphStart, paragraphEnd - paragraphStart);
-
-                                var paragraph = new Paragraph();
-
-                                var lineStart = 0;
-                                while (lineStart <= paragraphSpan.Length)
-                                {
-                                        var remaining = paragraphSpan.Slice(lineStart);
-                                        var lineBreakIndex = remaining.IndexOf('\n');
-                                        ReadOnlySpan<char> lineSpan;
-                                        if (lineBreakIndex < 0)
-                                        {
-                                                lineSpan = remaining;
-                                                lineStart = paragraphSpan.Length + 1;
-                                        }
-                                        else
-                                        {
-                                                lineSpan = remaining.Slice(0, lineBreakIndex);
-                                                lineStart += lineBreakIndex + 1;
-                                        }
-
-                                        if (paragraph.Inlines.Count > 0)
-                                                paragraph.Inlines.Add(new LineBreak());
-
-                                        paragraph.Inlines.Add(new Run(lineSpan.ToString()));
-                                }
-
-                                document.Blocks.Add(paragraph);
-
-                                if (separatorIndex < 0)
-                                        break;
-
-                                paragraphStart = separatorIndex + 2;
-                        }
+                        new TextRange(document.ContentStart, document.ContentEnd).Text = normalizedContent;
 
                         return document;
                 }


### PR DESCRIPTION
## Summary
- replace manual paragraph and run generation with a single `TextRange` assignment when building FlowDocument content
- normalize line endings prior to assigning text so WPF maintains expected paragraph and line breaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eab211bfac832db81abff3d110dc5a