### PR TITLE
Make clipboard hotkey handling asynchronous

### DIFF
--- a/Dissonance/Dissonance/Managers/ClipboardManager.cs
+++ b/Dissonance/Dissonance/Managers/ClipboardManager.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
 
@@ -92,7 +92,7 @@ namespace Dissonance.Managers
                         }
                 }
 
-                public string? CopySelectionAndGetValidatedText ( )
+                public async Task<string?> CopySelectionAndGetValidatedTextAsync ( )
                 {
                         var suppressionApplied = false;
                         var copySucceeded = false;
@@ -113,7 +113,7 @@ namespace Dissonance.Managers
 
                                 for ( var attempt = 0; attempt < 10; attempt++ )
                                 {
-                                        Thread.Sleep ( 25 );
+                                        await Task.Delay ( 25 );
 
                                         if ( !_clipboardService.IsTextAvailable ( ) )
                                                 continue;

--- a/Dissonance/Dissonance/Managers/HotkeyManager.cs
+++ b/Dissonance/Dissonance/Managers/HotkeyManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Speech.Synthesis;
+using System.Threading.Tasks;
 
 using Dissonance.Services.HotkeyService;
 using Dissonance.Services.SettingsService;
@@ -56,7 +57,7 @@ namespace Dissonance.Managers
                         _logger.LogInformation ( "HotkeyManager disposed." );
                 }
 
-                private void OnHotkeyPressed ( )
+                private async void OnHotkeyPressed ( )
                 {
                         if ( _isSpeaking )
                         {
@@ -66,7 +67,7 @@ namespace Dissonance.Managers
                                 return;
                         }
 
-                        SpeakClipboardContents ( );
+                        await SpeakClipboardContentsAsync ( );
                 }
 
                 private void OnClipboardTextReady ( object? sender, string clipboardText )
@@ -86,9 +87,9 @@ namespace Dissonance.Managers
                         _logger.LogInformation ( "TTS playback completed." );
                 }
 
-                private void SpeakClipboardContents ( )
+                private async Task SpeakClipboardContentsAsync ( )
                 {
-                        var clipboardText = _clipboardManager.CopySelectionAndGetValidatedText ( );
+                        var clipboardText = await _clipboardManager.CopySelectionAndGetValidatedTextAsync ( );
                         if ( string.IsNullOrEmpty ( clipboardText ) )
                         {
                                 clipboardText = _clipboardManager.GetValidatedClipboardText ( );


### PR DESCRIPTION
## Summary
- convert the clipboard polling helper to an async workflow that yields while waiting for copied text
- update the hotkey handler to await the clipboard copy task and keep the speaking logic unchanged

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eab4a34358832dba75d55e4622b842